### PR TITLE
 Search for libiio in standard CMake paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,25 +13,13 @@ find_package(std_msgs REQUIRED)
 find_path(
   IIO_INCLUDE_DIRS
   NAMES iio.h
-  HINTS ${CMAKE_INSTALL_PREFIX}/include
-        /include
-        /usr/include
-        /usr/local/include
-        /opt/local/include
-        REQUIRED
+  REQUIRED
 )
 
 find_library(
   IIO_LIBRARIES
   NAMES iio libiio
-  HINTS ${CMAKE_INSTALL_PREFIX}/lib
-        /usr/lib
-        /usr/lib64
-        /usr/local/lib
-        /usr/local/lib64
-        /opt/local/lib
-        /opt/local/lib64
-        REQUIRED
+  REQUIRED
 )
 
 find_package(rosidl_default_generators REQUIRED)


### PR DESCRIPTION
- Remove custom CMake `HINTS` for libiio since colcon build  automatically searches standard OS paths.
- This change ensures that libiio is properly found when installed via sudo from sources or using the package manager.
- Additionally, users can run `colcon --merge-install` in their `ros2_ws` (where both `libiio` and `iio_ros2` are built from source) to install them in `ros2_ws/install`.
