### PR TITLE
IIOPath services for device/channel/attr listing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/BufferEnableTopic.srv"
   "srv/BufferDisableTopic.srv"
   "srv/ListDevices.srv"
+  "srv/ListChannels.srv"
 
   DEPENDENCIES std_msgs
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/ListDevices.srv"
   "srv/ListChannels.srv"
   "srv/ListAttributes.srv"
+  "srv/ScanContext.srv"
 
   DEPENDENCIES std_msgs
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/BufferDestroy.srv"
   "srv/BufferEnableTopic.srv"
   "srv/BufferDisableTopic.srv"
+  "srv/ListDevices.srv"
 
   DEPENDENCIES std_msgs
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ rosidl_get_typesupport_target(adi_iio_srvs_typesupport_target ${PROJECT_NAME} "r
 
 add_executable(${NODE_NAME}
     src/iio_node.cpp
+    src/iio_path.cpp
     src/adi_iio.cpp
     src/iio_buffer.cpp
     src/iio_attr_topic.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/BufferDisableTopic.srv"
   "srv/ListDevices.srv"
   "srv/ListChannels.srv"
+  "srv/ListAttributes.srv"
 
   DEPENDENCIES std_msgs
 )

--- a/README.rst
+++ b/README.rst
@@ -228,21 +228,64 @@ This section provides a concise overview of the node-specific concepts for the
 ROS2 package. It details the conventions for attribute paths, topic naming,
 service responses, and buffer operations used when interfacing with IIO devices.
 
+.. _iio_path:
 
-.. _channel_and_device_attribute_path:
-
-Channel and Device Attribute Path
+IIO Path
 --------------------------------------------------------------------------------
 
-The ``attr_path`` parameter is used to specify the path to a specific attribute
-within an IIO device. This path follows the structure of the IIO context hierarchy.
+Services use the ``iio_path`` parameter to uniquely identify Industrial I/O
+(IIO) devices, channels, and attributes following the IIO context hierarchy.
+The ``/`` character is used to separate different levels of the hierarchy.
 
-**Example:**
+Context Path
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- An attribute path to a channel attribute might look like ``ad5592r/voltage0/raw``,
-  where ``ad5592r`` is the device name, ``voltage0`` is the channel, and ``raw``
-  is the attribute.
-- A path to a device attribute would be ``ad9361-phy/calib_mode``.
+- **Description:** an empty string is used to represent an IIO context.
+- **Format:** ``""`` (empty string.)
+
+Context Attribute Path (``attr_path``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **Description:** this path represents an attribute of a context.
+- **Format:** ``<context-attribute>``
+- **Example:** ``uri``, ``hw_vendor``, ``hw_serial``, etc.
+
+Device Path (``device_path``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **Description:** this path represents a device of a context.
+- **Format:** ``<device-name>``
+- **Example:** ``ad9361-phy``, ``ad5592r``, etc.
+
+Device Attribute Path (``attr_path``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **Description:** this path represents an attribute of a device.
+- **Format:** ``<device-name>/<device-attribute>``
+- **Example:** ``xadc/sampling_frequency``, etc.
+
+Channel Path (``channel_path``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **Format:** ``<device-name>/<channel-name>``
+- **Description:** this path represents a channel of a device.
+- **Example:** ``ad5592r/input_voltage0``, ``ad5592r/output_voltage0``,
+  ``ad9361-phy/voltage0``, etc.
+- **Note:** the channel name has an extended format which uses a prefix:
+  ``input_`` or ``output_`` to indicate the direction of data flow for channels
+  that share the same name. For example, ``ad5592r/input_voltage0`` and
+  ``ad5592r/output_voltage0`` are both valid paths that refer to two different
+  channels of the same device. When the prefix is not used (e.g:
+  ``ad5592r/voltage0``) but the device has both input and output channels, the
+  input channel has priority.
+
+Channel Attribute Path (``attr_path``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- **Format:** ``<device-name>/<channel-name>/<channel-attribute>``
+- **Description:** this path represents an attribute of a channel.
+- **Example:** ``ad5592r/input_voltage0/scale``, ``ad5592r/output_voltage0/scale``,
+  ``/cf-ad9361-lpc/voltage0/sampling_frequency``, etc.
 
 
 .. _topic_name_resolution:

--- a/README.rst
+++ b/README.rst
@@ -267,8 +267,8 @@ Device Attribute Path (``attr_path``)
 Channel Path (``channel_path``)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- **Format:** ``<device-name>/<channel-name>``
 - **Description:** this path represents a channel of a device.
+- **Format:** ``<device-name>/<channel-name>``
 - **Example:** ``ad5592r/input_voltage0``, ``ad5592r/output_voltage0``,
   ``ad9361-phy/voltage0``, etc.
 - **Note:** the channel name has an extended format which uses a prefix:
@@ -282,8 +282,8 @@ Channel Path (``channel_path``)
 Channel Attribute Path (``attr_path``)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- **Format:** ``<device-name>/<channel-name>/<channel-attribute>``
 - **Description:** this path represents an attribute of a channel.
+- **Format:** ``<device-name>/<channel-name>/<channel-attribute>``
 - **Example:** ``ad5592r/input_voltage0/scale``, ``ad5592r/output_voltage0/scale``,
   ``/cf-ad9361-lpc/voltage0/sampling_frequency``, etc.
 
@@ -406,170 +406,248 @@ AttrDisableTopic
 AttrEnableTopic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    **Description:** Enables a topic for a specific attribute.
+**Description:** Enables a topic for a specific attribute.
 
-    **Request:**
+**Request:**
 
-    * ``attr_path`` (string): The path to the attribute for which a topic will be enabled.
+* ``attr_path`` (string): The path to the attribute for which a topic will be enabled.
 
-    **Response:**
+**Response:**
 
-    * ``success`` (bool): Indicates whether the operation was successful.
-    * ``message`` (string): A message providing additional information.
+* ``success`` (bool): Indicates whether the operation was successful.
+* ``message`` (string): A message providing additional information.
 
 .. _AttrReadString:
 
 AttrReadString
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    **Description:** Reads an IIO attribute as a string.
+**Description:** Reads an IIO attribute as a string.
 
-    **Request:**
+**Request:**
 
-    * ``attr_path`` (string): The path to the attribute to be read.
+* ``attr_path`` (string): The path to the attribute to be read.
 
-    **Response:**
+**Response:**
 
-    * ``value`` (string): The value of the attribute.
-    * ``success`` (bool): Indicates whether the operation was successful.
-    * ``message`` (string): A message providing additional information.
+* ``value`` (string): The value of the attribute.
+* ``success`` (bool): Indicates whether the operation was successful.
+* ``message`` (string): A message providing additional information.
 
 .. _AttrWriteString:
 
 AttrWriteString
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    **Description:** Writes an IIO attribute as a string
+**Description:** Writes an IIO attribute as a string
 
-    **Request:**
+**Request:**
 
-    * ``attr_path`` (string): The path to the attribute to be written.
-    * ``value`` (string): The value to be written to the attribute.
+* ``attr_path`` (string): The path to the attribute to be written.
+* ``value`` (string): The value to be written to the attribute.
 
-    **Response:**
+**Response:**
 
-    * ``success`` (bool): Indicates whether the operation was successful.
-    * ``message`` (string): A message providing additional information.
+* ``success`` (bool): Indicates whether the operation was successful.
+* ``message`` (string): A message providing additional information.
 
 .. _BufferCreate:
 
 BufferCreate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    **Description:** Creates a buffer.
+**Description:** Creates a buffer.
 
-    **Request:**
+**Request:**
 
-    * ``device_path`` (string): The path to the device.
-    * ``channels`` (string[]): The channels to be read from the buffer.
-    * ``samples_count`` (int32): The number of samples for the buffer.
+* ``device_path`` (string): The path to the device.
+* ``channels`` (string[]): The channels to be read from the buffer.
+* ``samples_count`` (int32): The number of samples for the buffer.
 
-    **Response:**
+**Response:**
 
-    * ``success`` (bool): Indicates whether the operation was successful.
-    * ``message`` (string): A message providing additional information.
+* ``success`` (bool): Indicates whether the operation was successful.
+* ``message`` (string): A message providing additional information.
 
 .. _BufferDestroy:
 
 BufferDestroy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    **Description:** Destroys a buffer.
+**Description:** Destroys a buffer.
 
-    **Request:**
+**Request:**
 
-    * ``device_path`` (string): The path to the device.
+* ``device_path`` (string): The path to the device.
 
-    **Response:**
+**Response:**
 
-    * ``success`` (bool): Indicates whether the operation was successful.
-    * ``message`` (string): A message providing additional information.
+* ``success`` (bool): Indicates whether the operation was successful.
+* ``message`` (string): A message providing additional information.
 
 .. _BufferDisableTopic:
 
 BufferDisableTopic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    **Description:** Disables a topic for a buffer.
+**Description:** Disables a topic for a buffer.
 
-    **Request:**
-    * ``device_path`` (string): The path to the device.
+**Request:**
+* ``device_path`` (string): The path to the device.
 
-    **Response:**
-    * ``success`` (bool): Indicates whether the operation was successful.
-    * ``message`` (string): A message providing additional information.
+**Response:**
+* ``success`` (bool): Indicates whether the operation was successful.
+* ``message`` (string): A message providing additional information.
 
 .. _BufferEnableTopic:
 
 BufferEnableTopic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    **Description:** Enables a topic for a buffer.
+**Description:** Enables a topic for a buffer.
 
-    **Request:**
+**Request:**
 
-    * ``device_path`` (string): The path to the device.
-    * ``topic_name`` (string): The name of the topic to be enabled.
+* ``device_path`` (string): The path to the device.
+* ``topic_name`` (string): The name of the topic to be enabled.
 
-    **Response:**
+**Response:**
 
-    * ``success`` (bool): Indicates whether the operation was successful.
-    * ``message`` (string): A message providing additional information.
+* ``success`` (bool): Indicates whether the operation was successful.
+* ``message`` (string): A message providing additional information.
 
 .. _BufferRead:
 
 BufferRead
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    **Description:** Reads data from a buffer.
+**Description:** Reads data from a buffer.
 
-    **Request:**
+**Request:**
 
-    * ``device_path`` (string): The path to the device.
-    * ``channels`` (string[]): The channels to be read from the buffer.
-    * ``samples_count`` (int32): The number of samples to read.
+* ``device_path`` (string): The path to the device.
+* ``channels`` (string[]): The channels to be read from the buffer.
+* ``samples_count`` (int32): The number of samples to read.
 
-    **Response:**
+**Response:**
 
-    * ``success`` (bool): Indicates whether the operation was successful.
-    * ``message`` (string): A message providing additional information.
-    * ``buffer`` (Int32MultiArray): The data read from the buffer.
+* ``success`` (bool): Indicates whether the operation was successful.
+* ``message`` (string): A message providing additional information.
+* ``buffer`` (Int32MultiArray): The data read from the buffer.
 
 .. _BufferRefill:
 
 BufferRefill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    **Description:** Refills a buffer.
+**Description:** Refills a buffer.
 
-    **Request:**
+**Request:**
 
-    * ``device_path`` (string): The path to the device.
+* ``device_path`` (string): The path to the device.
 
-    **Response:**
+**Response:**
 
-    * ``success`` (bool): Indicates whether the operation was successful.
-    * ``message`` (string): A message providing additional information.
-    * ``buffer`` (Int32MultiArray): The data read from the buffer after refilling.
+* ``success`` (bool): Indicates whether the operation was successful.
+* ``message`` (string): A message providing additional information.
+* ``buffer`` (Int32MultiArray): The data read from the buffer after refilling.
 
 .. _BufferWrite:
 
 BufferWrite
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    **Description:** Writes data to a buffer.
+**Description:** Writes data to a buffer.
 
-    **Request:**
+**Request:**
 
-    * ``device_path`` (string): The path to the device.
-    * ``channels`` (string[]): The channels where data will be written.
-    * ``buffer`` (Int32MultiArray): The data to be written to the buffer.
-    * ``cyclic`` (bool): Indicates whether the buffer should be cyclic.
+* ``device_path`` (string): The path to the device.
+* ``channels`` (string[]): The channels where data will be written.
+* ``buffer`` (Int32MultiArray): The data to be written to the buffer.
+* ``cyclic`` (bool): Indicates whether the buffer should be cyclic.
 
-    **Response:**
+**Response:**
 
-    * ``success`` (bool): Indicates whether the operation was successful.
-    * ``message`` (string): A message providing additional information.
+* ``success`` (bool): Indicates whether the operation was successful.
+* ``message`` (string): A message providing additional information.
+
+.. _ScanContext:
+
+ScanContext
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Description:** Scans the  current IIO context and returns lists of devices,
+channels, and attributes formatted as IIO paths which can be used as request
+parameters for the other services.
+
+**Request:**
+
+* None. The operation uses the ``uri`` provided during node initialization to
+  scan for devices.
+
+**Response:**
+
+* ``success`` (bool): Indicates whether the operation was successful.
+* ``message`` (string): A message providing additional information.
+* ``devices`` (string[]): A list of IIO paths to the discovered devices.
+* ``channels`` (string[]): A list of IIO paths to the discovered channels.
+* ``context_attrs`` (string[]): A list of IIO paths to the discovered context attributes.
+* ``device_attrs`` (string[]): A list of IIO paths to the discovered device attributes.
+* ``channel_attrs`` (string[]): A list of IIO paths to the discovered channel attributes.
+
+.. _ListDevices:
+
+ListDevices
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Description:** Lists the IIO device paths found in the current context.
+
+**Request:**
+
+* None. The operation uses the ``uri`` provided during node initialization to
+  scan for devices.
+
+**Response:**
+
+* ``success`` (bool): Indicates whether the operation was successful.
+* ``message`` (string): A message providing additional information.
+* ``data`` (string[]): A list containing the IIO device paths.
+
+.. _ListChannels:
+
+ListChannels
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Description:** Lists the IIO channel paths found in the targeted device.
+
+**Request:**
+
+* ``iio_path`` (string): The IIO path to the device to be scanned.
+
+**Response:**
+
+* ``success`` (bool): Indicates whether the operation was successful.
+* ``message`` (string): A message providing additional information.
+* ``data`` (string[]): A list containing the IIO channel paths.
+
+.. _ListAttributes:
+
+ListAttributes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Description:** Lists the IIO attribute paths found in the target path. This
+can be either a context, device, or channel path.
+
+**Request:**
+
+* ``iio_path`` (string): The IIO path to a context,device or channel to be scanned.
+
+**Response:**
+
+* ``success`` (bool): Indicates whether the operation was successful.
+* ``message`` (string): A message providing additional information.
+* ``data`` (string[]): A list containing the IIO attribute paths.
+
 
 .. _launch:
 

--- a/include/adi_iio/iio_node.hpp
+++ b/include/adi_iio/iio_node.hpp
@@ -130,7 +130,7 @@ protected:
   template<typename T>
   void setErrorResponse(T & response, const std::string & message)
   {
-    RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "%s", message.c_str());
+    RCLCPP_ERROR(rclcpp::get_logger("adi_iio_node"), "%s", message.c_str());
     response->success = false;
     response->message = message;
   }
@@ -138,7 +138,7 @@ protected:
   template<typename T>
   void setWarningResponse(T & response, const std::string & message)
   {
-    RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "Warning: %s", message.c_str());
+    RCLCPP_DEBUG(rclcpp::get_logger("adi_iio_node"), "Warning: %s", message.c_str());
     response->success = false;
     response->message = message;
   }
@@ -146,7 +146,7 @@ protected:
   template<typename T>
   void setSuccessResponse(T & response, const std::string & message)
   {
-    RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "Success: %s", message.c_str());
+    RCLCPP_DEBUG(rclcpp::get_logger("adi_iio_node"), "Success: %s", message.c_str());
     response->success = true;
     response->message = message;
   }

--- a/include/adi_iio/iio_node.hpp
+++ b/include/adi_iio/iio_node.hpp
@@ -37,6 +37,7 @@
 #include "adi_iio/srv/buffer_enable_topic.hpp"
 #include "adi_iio/srv/buffer_disable_topic.hpp"
 #include "adi_iio/srv/list_devices.hpp"
+#include "adi_iio/srv/list_channels.hpp"
 
 class IIOAttrTopic;
 class IIOBuffer;
@@ -102,6 +103,11 @@ public:
   void listDevicesSrv(
     const std::shared_ptr<adi_iio::srv::ListDevices::Request> request,
     std::shared_ptr<adi_iio::srv::ListDevices::Response> response);
+
+  void listChannelsSrv(
+    const std::shared_ptr<adi_iio::srv::ListChannels::Request> request,
+    std::shared_ptr<adi_iio::srv::ListChannels::Response> response);
+
   // getters
   std::string uri();
   bool initialized();

--- a/include/adi_iio/iio_node.hpp
+++ b/include/adi_iio/iio_node.hpp
@@ -36,6 +36,7 @@
 #include "adi_iio/srv/buffer_write.hpp"
 #include "adi_iio/srv/buffer_enable_topic.hpp"
 #include "adi_iio/srv/buffer_disable_topic.hpp"
+#include "adi_iio/srv/list_devices.hpp"
 
 class IIOAttrTopic;
 class IIOBuffer;
@@ -97,6 +98,10 @@ public:
   void buffDisableTopicSrv(
     const std::shared_ptr<adi_iio::srv::BufferDisableTopic::Request> request,
     std::shared_ptr<adi_iio::srv::BufferDisableTopic::Response> response);
+
+  void listDevicesSrv(
+    const std::shared_ptr<adi_iio::srv::ListDevices::Request> request,
+    std::shared_ptr<adi_iio::srv::ListDevices::Response> response);
   // getters
   std::string uri();
   bool initialized();

--- a/include/adi_iio/iio_node.hpp
+++ b/include/adi_iio/iio_node.hpp
@@ -39,6 +39,7 @@
 #include "adi_iio/srv/list_devices.hpp"
 #include "adi_iio/srv/list_channels.hpp"
 #include "adi_iio/srv/list_attributes.hpp"
+#include "adi_iio/srv/scan_context.hpp"
 
 class IIOAttrTopic;
 class IIOBuffer;
@@ -112,6 +113,12 @@ public:
   void listAttributesSrv(
     const std::shared_ptr<adi_iio::srv::ListAttributes::Request> request,
     std::shared_ptr<adi_iio::srv::ListAttributes::Response> response);
+
+  void scanContextSrv(
+    const std::shared_ptr<adi_iio::srv::ScanContext::Request> request,
+    std::shared_ptr<adi_iio::srv::ScanContext::Response> response
+  );
+
   // getters
   std::string uri();
   bool initialized();

--- a/include/adi_iio/iio_node.hpp
+++ b/include/adi_iio/iio_node.hpp
@@ -102,6 +102,34 @@ public:
   bool initialized();
   iio_context * ctx();
 
+protected:
+  std::vector<iio_device *> getDevices(iio_context * ctx);
+  std::vector<iio_channel *> getChannels(iio_device * device);
+
+  template<typename T>
+  void setErrorResponse(T & response, const std::string & message)
+  {
+    RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Error: %s", message.c_str());
+    response->success = false;
+    response->message = message;
+  }
+
+  template<typename T>
+  void setWarningResponse(T & response, const std::string & message)
+  {
+    RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "Warning: %s", message.c_str());
+    response->success = false;
+    response->message = message;
+  }
+
+  template<typename T>
+  void setSuccessResponse(T & response, const std::string & message)
+  {
+    RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "Success: %s", message.c_str());
+    response->success = true;
+    response->message = message;
+  }
+
 private:
   bool m_initialized;
   std::string m_uri;

--- a/include/adi_iio/iio_node.hpp
+++ b/include/adi_iio/iio_node.hpp
@@ -55,7 +55,6 @@ public:
   bool rwAttrPath(
     std::string path, std::string & result, bool write = false,
     std::string value = "");
-  std::string convertAttrPathToTopicName(std::string path);
 
   // service handlers
   void attrReadSrv(
@@ -131,7 +130,7 @@ protected:
   template<typename T>
   void setErrorResponse(T & response, const std::string & message)
   {
-    RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "Error: %s", message.c_str());
+    RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "%s", message.c_str());
     response->success = false;
     response->message = message;
   }

--- a/include/adi_iio/iio_node.hpp
+++ b/include/adi_iio/iio_node.hpp
@@ -38,6 +38,7 @@
 #include "adi_iio/srv/buffer_disable_topic.hpp"
 #include "adi_iio/srv/list_devices.hpp"
 #include "adi_iio/srv/list_channels.hpp"
+#include "adi_iio/srv/list_attributes.hpp"
 
 class IIOAttrTopic;
 class IIOBuffer;
@@ -108,6 +109,9 @@ public:
     const std::shared_ptr<adi_iio::srv::ListChannels::Request> request,
     std::shared_ptr<adi_iio::srv::ListChannels::Response> response);
 
+  void listAttributesSrv(
+    const std::shared_ptr<adi_iio::srv::ListAttributes::Request> request,
+    std::shared_ptr<adi_iio::srv::ListAttributes::Response> response);
   // getters
   std::string uri();
   bool initialized();

--- a/include/adi_iio/iio_path.hpp
+++ b/include/adi_iio/iio_path.hpp
@@ -96,6 +96,12 @@ public:
   std::pair<bool, std::string> getExtendedChannelSegment() const;
 
   /**
+   * @brief Whether the channel segment has the extended syntax format.
+   *
+   */
+  bool hasExtendedChannelFormat() const;
+
+  /**
    * @brief Extracts the channel attribute segment from the path.
    *
    * @return The channel attribute as a string.
@@ -142,6 +148,16 @@ public:
    * @return The constructed channel segment as a string.
    */
   static std::string toExtendedChannelSegment(bool output, std::string chn_name);
+
+  /**
+   * @brief Converts a path to a ROS2 topic name.
+   *
+   * @param path The input path to be converted.
+   * @return The converted topic name as a string.
+   *
+   * @note ROS2 topic names cannot contain '-' characters.
+   */
+  static std::string toTopicName(std::string path);
 
 private:
   std::string m_base_path;

--- a/include/adi_iio/iio_path.hpp
+++ b/include/adi_iio/iio_path.hpp
@@ -1,0 +1,150 @@
+// Copyright 2025 Analog Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <vector>
+#include <string>
+#include <sstream>
+
+enum IIOPathType
+{
+  CONTEXT,
+  CONTEXT_ATTR,
+  DEVICE,
+  DEVICE_ATTR,
+  CHANNEL,
+  CHANNEL_ATTR,
+};
+
+/**
+ * @class IIOPath
+ * @brief Represents and manipulates Industrial I/O (IIO) paths that are used to
+ * uniquely identify IIO devices, attributes, and channels from a context.
+ *
+ * Examples of valid paths types:
+ * - CONTEXT: ""
+ * - CONTEXT_ATTR: "context-attribute"
+ * - DEVICE: "device-name"
+ * - DEVICE_ATTR: "device-name/attribute-name"
+ * - CHANNEL: "device-name/chn-prefix_channel-name"
+ * - CHANNEL_ATTR: "device-name/chn-prefix_channel-name/attribute-name"
+ */
+class IIOPath
+{
+public:
+  /**
+   * @brief Constructs an IIOPath object.
+   *
+   * @param path The base path for the IIO object.
+   * @param delimiter The character used to separate path segments (default is '/').
+   */
+  IIOPath(std::string path, char delimiter = '/');
+
+  /**
+   * @brief Retrieves the original path used to create this object.
+   *
+   * @return The base path as a string.
+   */
+  std::string basePath() const;
+
+  /**
+   * @brief Extracts the context attribute segment from the path.
+   *
+   * @return The context attribute as a string.
+   */
+  std::string getContextAttrSegment() const;
+
+  /**
+   * @brief Extracts the device name segment from the path.
+   *
+   * @return The device name as a string.
+   */
+  std::string getDeviceSegment() const;
+
+  /**
+   * @brief Extracts the device attribute segment from the path.
+   *
+   * @return The device attribute as a string.
+   */
+  std::string getDeviceAttrSegment() const;
+
+  /**
+   * @brief Extracts the channel name segment from the path.
+   *
+   * @return The channel name as a string.
+   */
+  std::string getChannelSegment() const;
+
+  /**
+   * @brief Extracts the channel information segment from the path.
+   *
+   * @return A pair containing a boolean indicating if the channel is of output
+   * type and the channel name as a string.
+   * @note The boolean variable helps to uniquely identify channels with
+   * the same name but different types (input/output).
+   */
+  std::pair<bool, std::string> getExtendedChannelSegment() const;
+
+  /**
+   * @brief Extracts the channel attribute segment from the path.
+   *
+   * @return The channel attribute as a string.
+   */
+  std::string getChannelAttrSegment() const;
+
+  /**
+   * @brief Appends a suffix to the current IIO path.
+   *
+   * The suffix is used to create a new path pointing to a specific attribute
+   * or nested element.
+   *
+   * @param suffix The string to append to the base path.
+   * @return The updated path as a string.
+   */
+  std::string append(const std::string & suffix);
+
+  /**
+   * @brief Validates the current IIO path based on the specified type.
+   *
+   * This function checks if the current path conforms to the expected structure
+   * for the given IIOPathType. It ensures that the path contains the necessary
+   * segments and follows the correct format for the specified type.
+   *
+   * @param type The type of IIO path to validate (e.g., `CONTEXT`, `DEVICE`, `CHANNEL`).
+   * @return True if the path is valid for the specified type, false otherwise.
+   */
+  bool isValid(const IIOPathType type);
+
+  /**
+   * @brief Splits a string into segments based on the delimiter.
+   *
+   * @param str The input string to be split.
+   * @return A vector of substrings obtained by splitting the input string.
+   */
+  std::vector<std::string> split(const std::string & str);
+
+  /**
+   *
+   * @brief Constructs the channel segment of the path.
+   *
+   * @param output A boolean indicating if the channel is an output channel.
+   * @param chn_name The name of the channel.
+   * @return The constructed channel segment as a string.
+   */
+  static std::string toExtendedChannelSegment(bool output, std::string chn_name);
+
+private:
+  std::string m_base_path;
+  char m_delimiter;
+  std::vector<std::string> m_segments;
+};

--- a/src/adi_iio.cpp
+++ b/src/adi_iio.cpp
@@ -100,6 +100,11 @@ int main(int argc, char ** argv)
     std::string(node->get_name()) + "/ListAttributes",
     std::bind(&IIONode::listAttributesSrv, node, std::placeholders::_1, std::placeholders::_2));
 
+  rclcpp::Service<adi_iio::srv::ScanContext>::SharedPtr scanContextSrv =
+    node->create_service<adi_iio::srv::ScanContext>(
+    std::string(node->get_name()) + "/ScanContext",
+    std::bind(&IIONode::scanContextSrv, node, std::placeholders::_1, std::placeholders::_2));
+
   RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "IIO Node");
 
   rclcpp::spin(node);

--- a/src/adi_iio.cpp
+++ b/src/adi_iio.cpp
@@ -24,7 +24,7 @@ int main(int argc, char ** argv)
   std::shared_ptr<IIONode> node = std::make_shared<IIONode>();
 
   if (!node->initialized()) {
-    RCLCPP_FATAL(rclcpp::get_logger("rclcpp"), "Node initialization failed.");
+    RCLCPP_FATAL(rclcpp::get_logger("adi_iio_node"), "Node initialization failed.");
     return EXIT_FAILURE;     // Fail if the node isn't properly initialized
   }
 
@@ -105,7 +105,7 @@ int main(int argc, char ** argv)
     std::string(node->get_name()) + "/ScanContext",
     std::bind(&IIONode::scanContextSrv, node, std::placeholders::_1, std::placeholders::_2));
 
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "IIO Node");
+  RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "IIO Node");
 
   rclcpp::spin(node);
   rclcpp::shutdown();

--- a/src/adi_iio.cpp
+++ b/src/adi_iio.cpp
@@ -85,6 +85,11 @@ int main(int argc, char ** argv)
     std::string(node->get_name()) + "/BufferDisableTopic",
     std::bind(&IIONode::buffDisableTopicSrv, node, std::placeholders::_1, std::placeholders::_2));
 
+  rclcpp::Service<adi_iio::srv::ListDevices>::SharedPtr listDevicesSrv =
+    node->create_service<adi_iio::srv::ListDevices>(
+    std::string(node->get_name()) + "/ListDevices",
+    std::bind(&IIONode::listDevicesSrv, node, std::placeholders::_1, std::placeholders::_2));
+
   RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "IIO Node");
 
   rclcpp::spin(node);

--- a/src/adi_iio.cpp
+++ b/src/adi_iio.cpp
@@ -90,6 +90,11 @@ int main(int argc, char ** argv)
     std::string(node->get_name()) + "/ListDevices",
     std::bind(&IIONode::listDevicesSrv, node, std::placeholders::_1, std::placeholders::_2));
 
+  rclcpp::Service<adi_iio::srv::ListChannels>::SharedPtr listChannelsSrv =
+    node->create_service<adi_iio::srv::ListChannels>(
+    std::string(node->get_name()) + "/ListChannels",
+    std::bind(&IIONode::listChannelsSrv, node, std::placeholders::_1, std::placeholders::_2));
+
   RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "IIO Node");
 
   rclcpp::spin(node);

--- a/src/adi_iio.cpp
+++ b/src/adi_iio.cpp
@@ -95,6 +95,11 @@ int main(int argc, char ** argv)
     std::string(node->get_name()) + "/ListChannels",
     std::bind(&IIONode::listChannelsSrv, node, std::placeholders::_1, std::placeholders::_2));
 
+  rclcpp::Service<adi_iio::srv::ListAttributes>::SharedPtr listAttributesSrv =
+    node->create_service<adi_iio::srv::ListAttributes>(
+    std::string(node->get_name()) + "/ListAttributes",
+    std::bind(&IIONode::listAttributesSrv, node, std::placeholders::_1, std::placeholders::_2));
+
   RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "IIO Node");
 
   rclcpp::spin(node);

--- a/src/attr_publisher.cpp
+++ b/src/attr_publisher.cpp
@@ -19,7 +19,7 @@ using std::placeholders::_1;
 
 StringPubSub::StringPubSub(std::shared_ptr<IIONode> nh, UpdateCallback * up, std::string topic)
 {
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Created String publisher ");
+  RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "Created String publisher ");
   m_topic = topic;
   m_nh = nh;
   m_updateCallback = up;
@@ -32,14 +32,14 @@ StringPubSub::StringPubSub(std::shared_ptr<IIONode> nh, UpdateCallback * up, std
 
 StringPubSub::~StringPubSub()
 {
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Deleted String publisher ");
+  RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "Deleted String publisher ");
   // shared ptr lifetime should delete this publisher automatically
 }
 
 void StringPubSub::publish(std::string msg)
 {
   RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"), "Publishing msg %s on topic %s",
+    rclcpp::get_logger("adi_iio_node"), "Publishing msg %s on topic %s",
     msg.c_str(), m_topic.c_str());
   auto message = std_msgs::msg::String();
   message.data = msg;
@@ -53,7 +53,7 @@ void StringPubSub::update(const std_msgs::msg::String & msg)
 
 Int32PubSub::Int32PubSub(std::shared_ptr<IIONode> nh, UpdateCallback * up, std::string topic)
 {
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Created Int32 publisher ");
+  RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "Created Int32 publisher ");
   m_topic = topic;
   m_nh = nh;
   m_updateCallback = up;
@@ -65,14 +65,14 @@ Int32PubSub::Int32PubSub(std::shared_ptr<IIONode> nh, UpdateCallback * up, std::
 
 Int32PubSub::~Int32PubSub()
 {
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Deleted Int32 publisher ");
+  RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "Deleted Int32 publisher ");
   // shared ptr lifetime should delete this publisher automatically
 }
 
 void Int32PubSub::publish(std::string msg)
 {
   RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"), "Publishing msg %s on topic %s",
+    rclcpp::get_logger("adi_iio_node"), "Publishing msg %s on topic %s",
     msg.c_str(), m_topic.c_str());
   auto message = std_msgs::msg::Int32();
   int32_t data = stoi(msg);
@@ -90,7 +90,7 @@ void Int32PubSub::update(const std_msgs::msg::Int32 & msg)
 
 BoolPubSub::BoolPubSub(std::shared_ptr<IIONode> nh, UpdateCallback * up, std::string topic)
 {
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Created Bool publisher ");
+  RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "Created Bool publisher ");
   m_topic = topic;
   m_nh = nh;
   m_updateCallback = up;
@@ -102,14 +102,14 @@ BoolPubSub::BoolPubSub(std::shared_ptr<IIONode> nh, UpdateCallback * up, std::st
 
 BoolPubSub::~BoolPubSub()
 {
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Deleted Bool publisher ");
+  RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "Deleted Bool publisher ");
   // shared ptr lifetime should delete this publisher automatically
 }
 
 void BoolPubSub::publish(std::string msg)
 {
   RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"), "Publishing msg %s on topic %s",
+    rclcpp::get_logger("adi_iio_node"), "Publishing msg %s on topic %s",
     msg.c_str(), m_topic.c_str());
   auto message = std_msgs::msg::Bool();
   bool data = stoi(msg);
@@ -127,7 +127,7 @@ void BoolPubSub::update(const std_msgs::msg::Bool & msg)
 
 Float32PubSub::Float32PubSub(std::shared_ptr<IIONode> nh, UpdateCallback * up, std::string topic)
 {
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Created Float32 publisher ");
+  RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "Created Float32 publisher ");
   m_topic = topic;
   m_nh = nh;
   m_updateCallback = up;
@@ -140,14 +140,14 @@ Float32PubSub::Float32PubSub(std::shared_ptr<IIONode> nh, UpdateCallback * up, s
 
 Float32PubSub::~Float32PubSub()
 {
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Deleted Float32 publisher ");
+  RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "Deleted Float32 publisher ");
   // shared ptr lifetime should delete this publisher automatically
 }
 
 void Float32PubSub::publish(std::string msg)
 {
   RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"), "Publishing msg %s on topic %s",
+    rclcpp::get_logger("adi_iio_node"), "Publishing msg %s on topic %s",
     msg.c_str(), m_topic.c_str());
   auto message = std_msgs::msg::Float32();
   bool data = stoi(msg);

--- a/src/iio_attr_topic.cpp
+++ b/src/iio_attr_topic.cpp
@@ -23,7 +23,7 @@ IIOAttrTopic::IIOAttrTopic(
   topicType_t type, int loopRate)
 : m_loopRate(loopRate)
 {
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Created IIOAttrTopic");
+  RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "Created IIOAttrTopic");
   m_nh = nh;
   m_attrPath = attrPath;
   m_topicName = topicName;
@@ -54,7 +54,7 @@ IIOAttrTopic::~IIOAttrTopic()
   if (m_th.joinable()) {
     m_th.join();
   }
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Deleted IIOAttrTopic");
+  RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "Deleted IIOAttrTopic");
 }
 
 void IIOAttrTopic::publishingLoop()

--- a/src/iio_buffer.cpp
+++ b/src/iio_buffer.cpp
@@ -41,7 +41,7 @@ void IIOBuffer::destroyIIOBuffer()
     std::lock_guard<std::mutex> lock(m_mutex);
     iio_buffer_destroy(m_buffer);
     m_buffer = nullptr;
-    RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "Destroyed buffer %p", (void *)m_buffer);
+    RCLCPP_DEBUG(rclcpp::get_logger("adi_iio_node"), "Destroyed buffer %p", (void *)m_buffer);
   }
 }
 
@@ -85,7 +85,7 @@ bool IIOBuffer::createIIOBuffer(std::string & message)
   // disable all channels
   for (unsigned int i = 0; i < iio_device_get_channels_count(dev); i++) {
     iio_channel_disable(iio_device_get_channel(dev, i));
-    RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "Disabling channel %d", i);
+    RCLCPP_DEBUG(rclcpp::get_logger("adi_iio_node"), "Disabling channel %d", i);
   }
 
   // enable channels
@@ -100,7 +100,7 @@ bool IIOBuffer::createIIOBuffer(std::string & message)
       return false;
     }
     iio_channel_enable(ch);
-    RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "Enabling channel %s", channel.c_str());
+    RCLCPP_DEBUG(rclcpp::get_logger("adi_iio_node"), "Enabling channel %s", channel.c_str());
   }
 
   m_canceled = false;
@@ -108,7 +108,8 @@ bool IIOBuffer::createIIOBuffer(std::string & message)
   if (m_buffer == nullptr) {
     message = strerror(-errno);
     RCLCPP_WARN(
-      rclcpp::get_logger("rclcpp"), "could not create buffer in device \"%s\" - errno %d - %s",
+      rclcpp::get_logger(
+        "adi_iio_node"), "could not create buffer in device \"%s\" - errno %d - %s",
       m_device_path.c_str(), errno, message.c_str());
     return false;
   }
@@ -124,7 +125,7 @@ bool IIOBuffer::createIIOBuffer(std::string & message)
   m_data.layout.dim[1].stride = m_channels.size();
 
 
-  RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "Created buffer %p", (void *)m_buffer);
+  RCLCPP_DEBUG(rclcpp::get_logger("adi_iio_node"), "Created buffer %p", (void *)m_buffer);
   message = "Success";
   return true;
 }
@@ -139,12 +140,13 @@ bool IIOBuffer::refill(std::string & message)
   }
 
   ssize_t size = iio_buffer_refill(m_buffer);
-  RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "Refilled buffer with %ld bytes from HW", size);
+  RCLCPP_DEBUG(rclcpp::get_logger("adi_iio_node"), "Refilled buffer with %ld bytes from HW", size);
 
   if (size < 0) {
     message = strerror(-errno);
     RCLCPP_WARN(
-      rclcpp::get_logger("rclcpp"), "could not refill buffer in device \"%s\" - errno %d - %s",
+      rclcpp::get_logger(
+        "adi_iio_node"), "could not refill buffer in device \"%s\" - errno %d - %s",
       m_device_path.c_str(), errno, message.c_str());
     return false;
   }
@@ -243,5 +245,5 @@ void IIOBuffer::disableTopic()
     m_th.join();  // stop thread
   }
   m_pub.reset();  // destroy topic
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Disabled IIOBuffer topic");
+  RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "Disabled IIOBuffer topic");
 }

--- a/src/iio_buffer.cpp
+++ b/src/iio_buffer.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "adi_iio/iio_buffer.hpp"
+#include "adi_iio/iio_path.hpp"
 
 IIOBuffer::IIOBuffer(std::shared_ptr<IIONode> nh, std::string device_path)
 {
@@ -204,9 +205,9 @@ void IIOBuffer::enableTopic(std::string topic_name)
   m_stopThread = false;
 
   if (topic_name == "") {
-    m_topic_name = m_nh->convertAttrPathToTopicName(m_device_path);
+    m_topic_name = IIOPath::toTopicName(m_device_path);
   } else {
-    m_topic_name = m_nh->convertAttrPathToTopicName(topic_name);
+    m_topic_name = IIOPath::toTopicName(topic_name);
   }
 
 

--- a/src/iio_node.cpp
+++ b/src/iio_node.cpp
@@ -21,22 +21,6 @@
 using namespace std::chrono_literals;
 
 #define MAX_ATTR_SIZE 4095
-/*
-BufferTopic.srv
-
-string buffer_path
-int buffer_size
-bool enable
----
-bool success
-string message
-
-
-parameter
-----
-"URI"
-
-*/
 
 IIONode::IIONode()
 : Node("adi_iio_node")
@@ -49,11 +33,14 @@ IIONode::IIONode()
 
   if (m_ctx != nullptr) {
     RCLCPP_INFO(
-      rclcpp::get_logger(
-        "rclcpp"), "creating context %p from uri %s", (void *)m_ctx, m_uri.c_str());
+      rclcpp::get_logger("rclcpp"),
+      "creating context %p from uri %s",
+      (void *)m_ctx, m_uri.c_str());
     m_initialized = true;
   } else {
-    RCLCPP_ERROR(rclcpp::get_logger("rclcpp"), "cannot create context from uri %s", m_uri.c_str());
+    RCLCPP_ERROR(
+      rclcpp::get_logger("rclcpp"),
+      "cannot create context from uri %s", m_uri.c_str());
   }
 }
 
@@ -83,223 +70,203 @@ bool IIONode::initialized()
   return m_initialized;
 }
 
-std::string IIONode::convertAttrPathToTopicName(std::string path)
-{
-  std::replace(path.begin(), path.end(), '-', '_');
-  return path;
-}
-
 bool IIONode::rwAttrPath(std::string path, std::string & result, bool write, std::string value)
 {
   bool ret = false;
-  std::string str = path;
-  std::stringstream ss(str);
-  std::string segment;
-  std::vector<std::string> segments;
+  IIOPath iio_path(path);
 
   iio_device * dev = nullptr;
   iio_channel * ch = nullptr;
 
-  while (std::getline(ss, segment, '/')) {
-    segments.push_back(segment);  // Push each part of the string into the vector
-  }
-
   char * val;
   char attr_val[MAX_ATTR_SIZE];
   int ret1;
-  switch (segments.size()) {
-    case 1:  // context_attribute
-      val = const_cast<char *>(iio_context_get_attr_value(m_ctx, segments[0].c_str()));
-      if (val) {
-        ret = true;
-        result = val;
-        RCLCPP_INFO(
-          rclcpp::get_logger("rclcpp"), "read context attribute \"%s\" with value \"%s\"",
-          segments[0].c_str(), val);
-      } else {
-        ret = false;
-        result = "";
-        RCLCPP_WARN(
-          rclcpp::get_logger(
-            "rclcpp"), "could not find context attribute \"%s\"", segments[0].c_str());
-      }
 
-      if (write) {
-        ret = false;
-        RCLCPP_WARN(rclcpp::get_logger("rclcpp"), "context attributes cannot be written");
-      }
-      break;
-
-    case 2:  // device_attribute
-      dev = iio_context_find_device(m_ctx, segments[0].c_str());
-      if (!dev) {
-        RCLCPP_WARN(
-          rclcpp::get_logger("rclcpp"), "could not find device \"%s\"",
-          segments[0].c_str());
-        break;
-      }
-      if (write) {
-        ret1 = iio_device_attr_write(dev, segments[1].c_str(), value.c_str());
-        if (ret1 > 0) {
-          RCLCPP_INFO(
-            rclcpp::get_logger("rclcpp"),
-            "wrote device attribute \"%s\" from device \"%s\" with value \"%s\"",
-            segments[1].c_str(),
-            segments[0].c_str(), value.c_str());
-        } else {
-          result = strerror(-ret1);
-          ret = false;
-          RCLCPP_WARN(
-            rclcpp::get_logger("rclcpp"),
-            "could not write attribute \"%s\" in device \"%s\" with value \"%s\" - errno %d - %s",
-            segments[1].c_str(), segments[0].c_str(), value.c_str(), ret1, result.c_str());
-          break;
-        }
-      }
-
-      ret1 = iio_device_attr_read(dev, segments[1].c_str(), attr_val, MAX_ATTR_SIZE);
-      if (ret1 > 0) {
-        result = attr_val;
-        ret = true;
-        RCLCPP_INFO(
-          rclcpp::get_logger(
-            "rclcpp"), "read device attribute \"%s\" from device \"%s\" with value \"%s\"",
-          segments[1].c_str(), segments[0].c_str(), attr_val);
-      } else {
-        result = strerror(-ret1);
-        ret = false;
-        RCLCPP_WARN(
-          rclcpp::get_logger(
-            "rclcpp"), "could not read attribute \"%s\" in device \"%s\" - errno %d - %s",
-          segments[1].c_str(), segments[0].c_str(), ret1, result.c_str());
-      }
-      break;
-
-    case 3:  // channel_attribute
-      dev = iio_context_find_device(m_ctx, segments[0].c_str());
-      if (!dev) {
-        RCLCPP_WARN(
-          rclcpp::get_logger("rclcpp"), "could not find device \"%s\"",
-          segments[0].c_str());
-        break;
-      }
-
-      if (segments[1].find("input_") == 0) {
-        ch = iio_device_find_channel(dev, segments[1].substr(strlen("input_")).c_str(), false);
-      } else if (segments[1].find("output_") == 0) {
-        ch = iio_device_find_channel(dev, segments[1].substr(strlen("output_")).c_str(), true);
-      } else {
-        ch = iio_device_find_channel(dev, segments[1].c_str(), false);
-        if (!ch) {
-          ch = iio_device_find_channel(dev, segments[1].c_str(), true);
-        }
-      }
-
-      if (!ch) {
-        RCLCPP_WARN(
-          rclcpp::get_logger("rclcpp"), "could not find channel \"%s\"",
-          segments[1].c_str());
-        break;
-      }
-
-      if (write) {
-        ret1 = iio_channel_attr_write(ch, segments[2].c_str(), value.c_str());
-        if (ret1 > 0) {
-          RCLCPP_INFO(
-            rclcpp::get_logger("rclcpp"),
-            "wrote channel attribute \"%s\" from channel \"%s\" device \"%s\" with value \"%s\"",
-            segments[2].c_str(), segments[1].c_str(), segments[0].c_str(), value.c_str());
-        } else {
-          result = strerror(-ret1);
-          ret = false;
-          RCLCPP_WARN(
-            rclcpp::get_logger(
-              "rclcpp"),
-            "could not write attribute \"%s\" from channel \"%s\" device \"%s\" with value \"%s\"- errno %d "
-            "- %s",
-            segments[2].c_str(), segments[1].c_str(), segments[0].c_str(), value.c_str(), ret1,
-            result.c_str());
-          break;
-        }
-      }
-
-      ret1 = iio_channel_attr_read(ch, segments[2].c_str(), attr_val, MAX_ATTR_SIZE);
-      if (ret1 > 0) {
-        result = attr_val;
-        ret = true;
-        RCLCPP_INFO(
-          rclcpp::get_logger("rclcpp"),
-          "read channel attribute \"%s\" from channel \"%s\" device \"%s\" with value \"%s\"",
-          segments[2].c_str(), segments[1].c_str(), segments[0].c_str(), attr_val);
-      } else {
-        result = strerror(-ret1);
-        ret = false;
-        RCLCPP_WARN(
-          rclcpp::get_logger("rclcpp"),
-          "could not read attribute \"%s\" from channel \"%s\" device \"%s\" - errno %d - %s",
-          segments[2].c_str(), segments[1].c_str(), segments[0].c_str(), ret1, result.c_str());
-      }
-
-      break;
-    default:
-      result = "Service requires attr_path";
+  if (iio_path.isValid(CONTEXT_ATTR)) {
+    val =
+      const_cast<char *>(iio_context_get_attr_value(
+        m_ctx,
+        iio_path.getContextAttrSegment().c_str()));
+    if (val) {
+      ret = true;
+      result = val;
+      RCLCPP_INFO(
+        rclcpp::get_logger("rclcpp"),
+        "read context attribute \"%s\" with value \"%s\"",
+        iio_path.getContextAttrSegment().c_str(), val);
+    } else {
       ret = false;
-      break;
+      result = "";
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"),
+        "could not find context attribute \"%s\"", iio_path.getContextAttrSegment().c_str());
+    }
+
+    if (write) {
+      ret = false;
+      RCLCPP_WARN(rclcpp::get_logger("rclcpp"), "context attributes cannot be written");
+    }
+  } else if (iio_path.isValid(DEVICE_ATTR)) {
+    dev = iio_context_find_device(m_ctx, iio_path.getDeviceSegment().c_str());
+    if (!dev) {
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"), "could not find device \"%s\"",
+        iio_path.getDeviceSegment().c_str());
+      return ret;
+    }
+
+    if (write) {
+      ret1 = iio_device_attr_write(dev, iio_path.getDeviceAttrSegment().c_str(), value.c_str());
+      if (ret1 > 0) {
+        RCLCPP_INFO(
+          rclcpp::get_logger("rclcpp"),
+          "wrote device attribute \"%s\" from device \"%s\" with value \"%s\"",
+          iio_path.getDeviceAttrSegment().c_str(), iio_path.getDeviceSegment().c_str(),
+          value.c_str());
+      } else {
+        result = strerror(-ret1);
+        ret = false;
+        RCLCPP_WARN(
+          rclcpp::get_logger("rclcpp"),
+          "could not write attribute \"%s\" in device \"%s\" with value \"%s\" - errno %d - %s",
+          iio_path.getDeviceAttrSegment().c_str(), iio_path.getDeviceSegment().c_str(),
+          value.c_str(), ret1, result.c_str());
+        return ret;
+      }
+    }
+
+    ret1 = iio_device_attr_read(
+      dev, iio_path.getDeviceAttrSegment().c_str(), attr_val, MAX_ATTR_SIZE);
+    if (ret1 > 0) {
+      result = attr_val;
+      ret = true;
+      RCLCPP_INFO(
+        rclcpp::get_logger("rclcpp"),
+        "read device attribute \"%s\" from device \"%s\" with value \"%s\"",
+        iio_path.getDeviceAttrSegment().c_str(), iio_path.getDeviceSegment().c_str(), attr_val);
+    } else {
+      result = strerror(-ret1);
+      ret = false;
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"),
+        "could not read attribute \"%s\" in device \"%s\" - errno %d - %s",
+        iio_path.getDeviceAttrSegment().c_str(),
+        iio_path.getDeviceSegment().c_str(), ret1, result.c_str());
+    }
+  } else if (iio_path.isValid(CHANNEL_ATTR)) {
+    dev = iio_context_find_device(m_ctx, iio_path.getDeviceSegment().c_str());
+    if (!dev) {
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"), "could not find device \"%s\"",
+        iio_path.getDeviceSegment().c_str());
+      return ret;
+    }
+
+    if (iio_path.hasExtendedChannelFormat()) {
+      auto [is_output, chn_name] = iio_path.getExtendedChannelSegment();
+      ch = iio_device_find_channel(dev, chn_name.c_str(), is_output);
+    } else {
+      ch = iio_device_find_channel(dev, iio_path.getChannelSegment().c_str(), false);
+      if (!ch) {
+        ch = iio_device_find_channel(dev, iio_path.getChannelSegment().c_str(), true);
+      }
+    }
+
+    if (!ch) {
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"), "could not find channel \"%s\"",
+        iio_path.getChannelSegment().c_str());
+      return ret;
+    }
+
+    if (write) {
+      ret1 = iio_channel_attr_write(ch, iio_path.getChannelAttrSegment().c_str(), value.c_str());
+      if (ret1 > 0) {
+        RCLCPP_INFO(
+          rclcpp::get_logger("rclcpp"),
+          "wrote channel attribute \"%s\" from channel \"%s\" device \"%s\" with value \"%s\"",
+          iio_path.getChannelAttrSegment().c_str(),
+          iio_path.getChannelSegment().c_str(), iio_path.getDeviceSegment().c_str(), value.c_str());
+      } else {
+        result = strerror(-ret1);
+        ret = false;
+        RCLCPP_WARN(
+          rclcpp::get_logger(
+            "adi_iio_node"),
+          "could not write attribute \"%s\" from channel \"%s\" device \"%s\" with value \"%s\"- errno %d - %s",
+          iio_path.getChannelAttrSegment().c_str(), iio_path.getChannelSegment().c_str(),
+          iio_path.getDeviceSegment().c_str(), value.c_str(), ret1, result.c_str());
+        return ret;
+      }
+    }
+
+    ret1 = iio_channel_attr_read(
+      ch, iio_path.getChannelAttrSegment().c_str(), attr_val, MAX_ATTR_SIZE);
+    if (ret1 > 0) {
+      result = attr_val;
+      ret = true;
+      RCLCPP_INFO(
+        rclcpp::get_logger("rclcpp"),
+        "read channel attribute \"%s\" from channel \"%s\" device \"%s\" with value \"%s\"",
+        iio_path.getChannelAttrSegment().c_str(), iio_path.getChannelSegment().c_str(),
+        iio_path.getDeviceSegment().c_str(), attr_val);
+    } else {
+      result = strerror(-ret1);
+      ret = false;
+      RCLCPP_WARN(
+        rclcpp::get_logger("rclcpp"),
+        "could not read attribute \"%s\" from channel \"%s\" device \"%s\" - errno %d - %s",
+        iio_path.getChannelAttrSegment().c_str(), iio_path.getChannelSegment().c_str(),
+        iio_path.getDeviceSegment().c_str(), ret1, result.c_str());
+    }
+  } else {
+    result = "Service requires a valid attr_path";
+    ret = false;
   }
 
   return ret;
 }
 
 void IIONode::attrReadSrv(
-  const std::shared_ptr<adi_iio::srv::AttrReadString::Request> request,                          // CHANGE
+  const std::shared_ptr<adi_iio::srv::AttrReadString::Request> request,   // CHANGE
   std::shared_ptr<adi_iio::srv::AttrReadString::Response> response)
 {
   RCLCPP_INFO(
-    rclcpp::get_logger(
-      "rclcpp"), "Service request read attr: %s", request->attr_path.c_str());
+    rclcpp::get_logger("rclcpp"), "Service request /AttrReadString : %s",
+    request->attr_path.c_str());
   std::string result;
   response->success = rwAttrPath(request->attr_path, result);
   response->message = result;
 }
 
 void IIONode::attrWriteSrv(
-  const std::shared_ptr<adi_iio::srv::AttrWriteString::Request> request,                           // CHANGE
+  const std::shared_ptr<adi_iio::srv::AttrWriteString::Request> request,   // CHANGE
   std::shared_ptr<adi_iio::srv::AttrWriteString::Response> response)
 {
   RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"), "Service request write attr %s value %s",
-    request->attr_path.c_str(),
-    request->value.c_str());
+    rclcpp::get_logger("rclcpp"), "Service request /AttrWriteString : %s value %s",
+    request->attr_path.c_str(), request->value.c_str());
   std::string result;
   response->success = rwAttrPath(request->attr_path, result, true, request->value);
   response->message = result;
 }
-
-/*AttrTopicEnable.srv
- string topic_name
- string attr_path
- int loop_rate
- int type
- ---------------
- bool success
- string message*/
 
 void IIONode::attrEnableTopicSrv(
   const std::shared_ptr<adi_iio::srv::AttrEnableTopic::Request> request,
   std::shared_ptr<adi_iio::srv::AttrEnableTopic::Response> response)
 {
   RCLCPP_INFO(
-    rclcpp::get_logger(
-      "rclcpp"), "Service request enable topic %s with type %s with loop_rate %d Hz",
+    rclcpp::get_logger("rclcpp"),
+    "Service request /AttrEnableTopic %s with type %s with loop_rate %d Hz",
     request->attr_path.c_str(), request->attr_path.c_str(), request->loop_rate);
 
-  std::string result;
-  response->success = rwAttrPath(request->attr_path, result);
-  response->message = result;
+  std::string message;
+  response->success = rwAttrPath(request->attr_path, message);
+  response->message = message;
 
   std::string local_topic_name = request->topic_name;
   if (local_topic_name == "") {
-    local_topic_name = convertAttrPathToTopicName(request->attr_path);
+    local_topic_name = IIOPath::toTopicName(request->attr_path);
   }
 
   if (response->success) {
@@ -314,37 +281,32 @@ void IIONode::attrEnableTopicSrv(
           request->attr_path, static_cast<IIOAttrTopic::topicType_t>(request->type),
           request->loop_rate)});
 
-    response->success = true;
-    response->message = "Success";
+    setSuccessResponse(response, "Success");
+  } else {
+    setErrorResponse(response, message);
   }
 }
-
-/*
-AttrTopicDisable.srv
-string topic_name
----
-bool success
-string message
-*/
 
 void IIONode::attrDisableTopicSrv(
   const std::shared_ptr<adi_iio::srv::AttrDisableTopic::Request> request,
   std::shared_ptr<adi_iio::srv::AttrDisableTopic::Response> response)
 {
   RCLCPP_INFO(
-    rclcpp::get_logger(
-      "rclcpp"), "Service request disable topic %s ", request->topic_name.c_str());
+    rclcpp::get_logger("rclcpp"), "Service request /AttrDisableTopic %s ",
+    request->topic_name.c_str());
+
+  std::string message;
 
   std::string local_topic_name = request->topic_name;
-  local_topic_name = convertAttrPathToTopicName(request->topic_name);  // for compatibility with enable
+  local_topic_name = IIOPath::toTopicName(request->topic_name); // for compatibility with enable
 
   if (m_attrTopicMap.find(local_topic_name) != m_attrTopicMap.end()) {
     m_attrTopicMap.erase(local_topic_name);
-    response->success = true;
-    response->message = "Success";
+    message = "Success";
+    setSuccessResponse(response, message);
   } else {
-    response->success = false;
-    response->message = "Topic not found";
+    message = "Topic not found";
+    setErrorResponse(response, message);
   }
 }
 
@@ -352,18 +314,37 @@ void IIONode::buffRefillSrv(
   const std::shared_ptr<adi_iio::srv::BufferRefill::Request> request,
   std::shared_ptr<adi_iio::srv::BufferRefill::Response> response)
 {
-  if (m_bufferMap.find(request->device_path) == m_bufferMap.end()) {
-    response->success = false;
-    response->message = "Buffer not found";
-  } else {
-    std::string message;
-    if (m_bufferMap[request->device_path]->topic_enabled()) {
-    } else {
-      response->success = m_bufferMap[request->device_path]->refill(message);
-      response->message = message;
-    }
-    response->buffer = m_bufferMap[request->device_path]->data();
+  RCLCPP_INFO(
+    rclcpp::get_logger("rclcpp"), "Service request /BufferRill %s",
+    request->device_path.c_str());
+
+  std::string message;
+  bool success = true;
+
+  IIOPath path(request->device_path);
+  if (!path.isValid(IIOPathType::DEVICE)) {
+    message = request->device_path + " is not a valid device path";
+    setErrorResponse(response, message);
+    return;
   }
+
+  if (m_bufferMap.find(path.getDeviceSegment()) == m_bufferMap.end()) {
+    message = "Buffer not found";
+    setErrorResponse(response, message);
+    return;
+  }
+
+  if (!m_bufferMap[path.getDeviceSegment()]->topic_enabled()) {
+    success = m_bufferMap[path.getDeviceSegment()]->refill(message);
+  }
+
+  if (!success) {
+    setErrorResponse(response, message);
+    return;
+  }
+
+  setSuccessResponse(response, message);
+  response->buffer = m_bufferMap[path.getDeviceSegment()]->data();
 }
 
 void IIONode::buffReadSrv(
@@ -376,34 +357,45 @@ void IIONode::buffReadSrv(
   }
 
   RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"), "Service request buffer read %s - %s - %d samples",
+    rclcpp::get_logger("rclcpp"), "Service request /BufferRead %s - %s - %d samples",
     request->device_path.c_str(), channels.c_str(), request->samples_count);
 
   std::string message;
 
-  std::shared_ptr<IIOBuffer> buffer;
-  if (m_bufferMap.find(request->device_path) == m_bufferMap.end()) {
-    response->success = false;
-    response->message = "Device or buffer not found";
+  IIOPath path(request->device_path);
+  if (!path.isValid(IIOPathType::DEVICE)) {
+    message = request->device_path + " is not a valid device path";
+    setErrorResponse(response, message);
     return;
   }
 
-  buffer = m_bufferMap[request->device_path];
+  std::shared_ptr<IIOBuffer> buffer;
+  if (m_bufferMap.find(path.getDeviceSegment()) == m_bufferMap.end()) {
+    message = "Device or buffer not found.";
+    setErrorResponse(response, message);
+    return;
+  }
+
+  buffer = m_bufferMap[path.getDeviceSegment()];
   buffer->destroyIIOBuffer();
   buffer->set_samples_count(request->samples_count);
   buffer->set_channels(request->channels);
 
-  response->success = buffer->createIIOBuffer(message);
-  if (!response->success) {
-    response->message = message;
+  bool success = buffer->createIIOBuffer(message);
+  if (!success) {
+    setErrorResponse(response, message);
     return;
   }
 
-  response->success = buffer->refill(message);
-  response->buffer = buffer->data();
-  response->message = message;
-}
+  success = buffer->refill(message);
+  if (!success) {
+    setErrorResponse(response, message);
+    return;
+  }
 
+  setSuccessResponse(response, message);
+  response->buffer = buffer->data();
+}
 
 void IIONode::buffWriteSrv(
   const std::shared_ptr<adi_iio::srv::BufferWrite::Request> request,
@@ -415,30 +407,42 @@ void IIONode::buffWriteSrv(
   }
 
   RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"), "Service request buffer read %s - %s - %d samples",
+    rclcpp::get_logger("rclcpp"), "Service request /BufferWrite %s - %s - %d samples",
     request->device_path.c_str(), channels.c_str(), request->buffer.layout.dim[0].size);
 
   std::string message;
 
-  std::shared_ptr<IIOBuffer> buffer;
-  if (m_bufferMap.find(request->device_path) == m_bufferMap.end()) {
-    response->success = false;
-    response->message = "Device or buffer not found";
+  IIOPath path(request->device_path);
+  if (!path.isValid(IIOPathType::DEVICE)) {
+    message = request->device_path + " is not a valid device path";
+    setErrorResponse(response, message);
     return;
   }
 
-  buffer = m_bufferMap[request->device_path];
+  std::shared_ptr<IIOBuffer> buffer;
+  if (m_bufferMap.find(path.getDeviceSegment()) == m_bufferMap.end()) {
+    message = "Device or buffer not found.";
+    setErrorResponse(response, message);
+    return;
+  }
+
+  buffer = m_bufferMap[path.getDeviceSegment()];
   buffer->destroyIIOBuffer();
   buffer->set_samples_count(request->buffer.layout.dim[0].size);
   buffer->set_channels(request->channels);
 
-  response->success = buffer->createIIOBuffer(message);
-  if (!response->success) {
-    response->message = message;
+  bool success = buffer->createIIOBuffer(message);
+  if (!success) {
+    setErrorResponse(response, message);
     return;
   }
 
-  response->success = buffer->push(message, request->buffer);
+  success = buffer->push(message, request->buffer);
+  if (!success) {
+    setErrorResponse(response, message);
+    return;
+  }
+  setSuccessResponse(response, message);
 }
 
 void IIONode::buffCreateSrv(
@@ -451,24 +455,37 @@ void IIONode::buffCreateSrv(
   }
 
   RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"), "Service request buffer create %s - %s - %d samples",
+    rclcpp::get_logger("rclcpp"),
+    "Service request /BufferCreate %s - %s - %d samples",
     request->device_path.c_str(), channels.c_str(), request->samples_count);
 
   std::string message;
 
-  std::shared_ptr<IIOBuffer> buffer;
-  if (m_bufferMap.find(request->device_path) == m_bufferMap.end()) {
-    response->success = false;
-    response->message = "Buffer not found";
+  IIOPath path(request->device_path);
+  if (!path.isValid(IIOPathType::DEVICE)) {
+    message = request->device_path + " is not a valid device path";
+    setErrorResponse(response, message);
+    return;
   }
 
-  buffer = m_bufferMap[request->device_path];
+  std::shared_ptr<IIOBuffer> buffer;
+  if (m_bufferMap.find(path.getDeviceSegment()) == m_bufferMap.end()) {
+    message = "Buffer not found";
+    setWarningResponse(response, message);
+  }
+
+  buffer = m_bufferMap[path.getDeviceSegment()];
   buffer->destroyIIOBuffer();
   buffer->set_samples_count(request->samples_count);
   buffer->set_channels(request->channels);
 
-  response->success = buffer->createIIOBuffer(message);
-  response->message = message;
+  bool success = buffer->createIIOBuffer(message);
+  if (!success) {
+    setErrorResponse(response, message);
+    return;
+  }
+
+  setSuccessResponse(response, message);
 }
 
 void IIONode::buffDestroySrv(
@@ -476,33 +493,55 @@ void IIONode::buffDestroySrv(
   std::shared_ptr<adi_iio::srv::BufferDestroy::Response> response)
 {
   RCLCPP_INFO(
-    rclcpp::get_logger(
-      "rclcpp"), "Service request buffer destroy %s", request->device_path.c_str());
+    rclcpp::get_logger("rclcpp"),
+    "Service request /BufferDestroy %s", request->device_path.c_str());
 
-  if (m_bufferMap.find(request->device_path) != m_bufferMap.end()) {
-    if (m_bufferMap[request->device_path]->buffer()) {
-      m_bufferMap[request->device_path]->destroyIIOBuffer();
-      response->success = true;
-      response->message = "Success";
+  std::string msg;
+
+  IIOPath path(request->device_path);
+  if (!path.isValid(IIOPathType::DEVICE)) {
+    msg = request->device_path + " is not a valid device path";
+    setErrorResponse(response, msg);
+    return;
+  }
+
+  if (m_bufferMap.find(path.getDeviceSegment()) != m_bufferMap.end()) {
+    if (m_bufferMap[path.getDeviceSegment()]->buffer()) {
+      m_bufferMap[path.getDeviceSegment()]->destroyIIOBuffer();
+      msg = "Success";
+      setSuccessResponse(response, msg);
       return;
     }
   }
 
-  response->success = false;
-  response->message = "Buffer not found";
+  msg = "Buffer not found";
+  setWarningResponse(response, msg);
 }
 
 void IIONode::buffEnableTopicSrv(
   const std::shared_ptr<adi_iio::srv::BufferEnableTopic::Request> request,
   std::shared_ptr<adi_iio::srv::BufferEnableTopic::Response> response)
 {
-  if (m_bufferMap.find(request->device_path) != m_bufferMap.end()) {
-    m_bufferMap[request->device_path]->enableTopic(request->topic_name);
-    response->success = true;
-    response->message = "Success";
+  RCLCPP_INFO(
+    rclcpp::get_logger("rclcpp"),
+    "Service request /BufferEnableTopic %s", request->device_path.c_str());
+
+  std::string msg;
+
+  IIOPath path(request->device_path);
+  if (!path.isValid(IIOPathType::DEVICE)) {
+    msg = request->device_path + " is not a valid device path";
+    setErrorResponse(response, msg);
+    return;
+  }
+
+  if (m_bufferMap.find(path.getDeviceSegment()) != m_bufferMap.end()) {
+    m_bufferMap[path.getDeviceSegment()]->enableTopic(request->topic_name);
+    msg = "Success";
+    setSuccessResponse(response, msg);
   } else {
-    response->success = false;
-    response->message = "Buffer not found";
+    msg = "Buffer not found";
+    setWarningResponse(response, msg);
   }
 }
 
@@ -510,13 +549,26 @@ void IIONode::buffDisableTopicSrv(
   const std::shared_ptr<adi_iio::srv::BufferDisableTopic::Request> request,
   std::shared_ptr<adi_iio::srv::BufferDisableTopic::Response> response)
 {
-  if (m_bufferMap.find(request->device_path) != m_bufferMap.end()) {
-    m_bufferMap[request->device_path]->disableTopic();
-    response->success = true;
-    response->message = "Success";
+  RCLCPP_INFO(
+    rclcpp::get_logger("rclcpp"),
+    "Service request /BufferDisableTopic %s", request->device_path.c_str());
+
+  std::string msg;
+
+  IIOPath path(request->device_path);
+  if (!path.isValid(IIOPathType::DEVICE)) {
+    msg = request->device_path + " is not a valid device path";
+    setErrorResponse(response, msg);
+    return;
+  }
+
+  if (m_bufferMap.find(path.getDeviceSegment()) != m_bufferMap.end()) {
+    m_bufferMap[path.getDeviceSegment()]->disableTopic();
+    msg = "Success";
+    setSuccessResponse(response, msg);
   } else {
-    response->success = false;
-    response->message = "Buffer not found";
+    msg = "Buffer not found";
+    setWarningResponse(response, msg);
   }
 }
 
@@ -524,7 +576,7 @@ void IIONode::listDevicesSrv(
   const std::shared_ptr<adi_iio::srv::ListDevices::Request> request,
   std::shared_ptr<adi_iio::srv::ListDevices::Response> response)
 {
-  RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "Service request: /ListDevices");
+  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Service request /ListDevices");
   std::string msg;
 
   IIOPath path("");
@@ -546,7 +598,7 @@ void IIONode::listChannelsSrv(
   const std::shared_ptr<adi_iio::srv::ListChannels::Request> request,
   std::shared_ptr<adi_iio::srv::ListChannels::Response> response)
 {
-  RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "Service request: /ListChannels");
+  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Service request /ListChannels");
   std::string msg;
 
   IIOPath path(request->iio_path);
@@ -583,7 +635,7 @@ void IIONode::listAttributesSrv(
   const std::shared_ptr<adi_iio::srv::ListAttributes::Request> request,
   std::shared_ptr<adi_iio::srv::ListAttributes::Response> response)
 {
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Service request: /ListAttributes");
+  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Service request /ListAttributes");
   std::string msg;
   std::vector<std::string> data;
 
@@ -603,7 +655,8 @@ void IIONode::listAttributesSrv(
         err_str = strerror(-ret);
         RCLCPP_WARN(
           rclcpp::get_logger(
-            "rclcpp"), "Unable to read IIO context attribute: %s", err_str.c_str());
+            "adi_iio_node"),
+          "Unable to read IIO context attribute: %s", err_str.c_str());
       }
     }
     msg = "Found " + std::to_string(data.size()) + " attributes";
@@ -631,10 +684,18 @@ void IIONode::listAttributesSrv(
       return;
     }
 
-    auto [is_output, chn_name] = path.getExtendedChannelSegment();
-    iio_channel * chn = iio_device_find_channel(dev, chn_name.c_str(), is_output);
+    iio_channel * chn;
+    if (path.hasExtendedChannelFormat()) {
+      auto [is_output, chn_name] = path.getExtendedChannelSegment();
+      chn = iio_device_find_channel(dev, chn_name.c_str(), is_output);
+    } else {
+      chn = iio_device_find_channel(dev, path.getChannelSegment().c_str(), false);
+      if (chn == nullptr) {
+        chn = iio_device_find_channel(dev, path.getChannelSegment().c_str(), true);
+      }
+    }
     if (chn == nullptr) {
-      msg = "Could not find channel: " + chn_name;
+      msg = "Could not find channel: " + path.getChannelSegment();
       setWarningResponse(response, msg);
       return;
     }
@@ -643,7 +704,8 @@ void IIONode::listAttributesSrv(
       std::string attr_key = iio_channel_get_attr(chn, i);
       data.push_back(path.append(attr_key));
     }
-    msg = "Found " + std::to_string(data.size()) + " attributes in channel: " + chn_name;
+    msg = "Found " + std::to_string(data.size()) + " attributes in channel: " +
+      path.getChannelSegment();
   } else {
     msg = "Invalid path: " + request->iio_path;
     setErrorResponse(response, msg);
@@ -658,7 +720,7 @@ void IIONode::scanContextSrv(
   const std::shared_ptr<adi_iio::srv::ScanContext::Request> request,
   std::shared_ptr<adi_iio::srv::ScanContext::Response> response)
 {
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Service request: /ScanContext");
+  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Service request /ScanContext");
   std::string msg{"Found: "};
   std::vector<std::string> devices;
   std::vector<std::string> channels;
@@ -680,7 +742,7 @@ void IIONode::scanContextSrv(
       err_str = strerror(-ret);
       RCLCPP_WARN(
         rclcpp::get_logger(
-          "rclcpp"),
+          "adi_iio_node"),
         "Unable to read IIO context attribute: %s", err_str.c_str());
     }
   }

--- a/src/iio_node.cpp
+++ b/src/iio_node.cpp
@@ -519,6 +519,29 @@ void IIONode::buffDisableTopicSrv(
     response->message = "Buffer not found";
   }
 }
+
+void IIONode::listDevicesSrv(
+  const std::shared_ptr<adi_iio::srv::ListDevices::Request> request,
+  std::shared_ptr<adi_iio::srv::ListDevices::Response> response)
+{
+  RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "Service request: /ListDevices");
+  std::string msg;
+
+  IIOPath path("");
+  std::vector<std::string> data;
+
+  auto devices_ptr = getDevices(ctx());
+  for (iio_device * dev : devices_ptr) {
+    auto dev_name = std::string(iio_device_get_name(dev));
+    auto dev_path = path.append(dev_name);
+    data.push_back(dev_path);
+  }
+
+  msg = "Found " + std::to_string(data.size()) + " devices";
+  setSuccessResponse(response, msg);
+  response->data = {data};
+}
+
 std::vector<iio_device *> IIONode::getDevices(iio_context * ctx)
 {
   std::vector<iio_device *> devices;

--- a/src/iio_node.cpp
+++ b/src/iio_node.cpp
@@ -33,13 +33,13 @@ IIONode::IIONode()
 
   if (m_ctx != nullptr) {
     RCLCPP_INFO(
-      rclcpp::get_logger("rclcpp"),
+      rclcpp::get_logger("adi_iio_node"),
       "creating context %p from uri %s",
       (void *)m_ctx, m_uri.c_str());
     m_initialized = true;
   } else {
     RCLCPP_ERROR(
-      rclcpp::get_logger("rclcpp"),
+      rclcpp::get_logger("adi_iio_node"),
       "cannot create context from uri %s", m_uri.c_str());
   }
 }
@@ -91,26 +91,26 @@ bool IIONode::rwAttrPath(std::string path, std::string & result, bool write, std
       ret = true;
       result = val;
       RCLCPP_INFO(
-        rclcpp::get_logger("rclcpp"),
+        rclcpp::get_logger("adi_iio_node"),
         "read context attribute \"%s\" with value \"%s\"",
         iio_path.getContextAttrSegment().c_str(), val);
     } else {
       ret = false;
       result = "";
       RCLCPP_WARN(
-        rclcpp::get_logger("rclcpp"),
+        rclcpp::get_logger("adi_iio_node"),
         "could not find context attribute \"%s\"", iio_path.getContextAttrSegment().c_str());
     }
 
     if (write) {
       ret = false;
-      RCLCPP_WARN(rclcpp::get_logger("rclcpp"), "context attributes cannot be written");
+      RCLCPP_WARN(rclcpp::get_logger("adi_iio_node"), "context attributes cannot be written");
     }
   } else if (iio_path.isValid(DEVICE_ATTR)) {
     dev = iio_context_find_device(m_ctx, iio_path.getDeviceSegment().c_str());
     if (!dev) {
       RCLCPP_WARN(
-        rclcpp::get_logger("rclcpp"), "could not find device \"%s\"",
+        rclcpp::get_logger("adi_iio_node"), "could not find device \"%s\"",
         iio_path.getDeviceSegment().c_str());
       return ret;
     }
@@ -119,7 +119,7 @@ bool IIONode::rwAttrPath(std::string path, std::string & result, bool write, std
       ret1 = iio_device_attr_write(dev, iio_path.getDeviceAttrSegment().c_str(), value.c_str());
       if (ret1 > 0) {
         RCLCPP_INFO(
-          rclcpp::get_logger("rclcpp"),
+          rclcpp::get_logger("adi_iio_node"),
           "wrote device attribute \"%s\" from device \"%s\" with value \"%s\"",
           iio_path.getDeviceAttrSegment().c_str(), iio_path.getDeviceSegment().c_str(),
           value.c_str());
@@ -127,7 +127,7 @@ bool IIONode::rwAttrPath(std::string path, std::string & result, bool write, std
         result = strerror(-ret1);
         ret = false;
         RCLCPP_WARN(
-          rclcpp::get_logger("rclcpp"),
+          rclcpp::get_logger("adi_iio_node"),
           "could not write attribute \"%s\" in device \"%s\" with value \"%s\" - errno %d - %s",
           iio_path.getDeviceAttrSegment().c_str(), iio_path.getDeviceSegment().c_str(),
           value.c_str(), ret1, result.c_str());
@@ -141,14 +141,14 @@ bool IIONode::rwAttrPath(std::string path, std::string & result, bool write, std
       result = attr_val;
       ret = true;
       RCLCPP_INFO(
-        rclcpp::get_logger("rclcpp"),
+        rclcpp::get_logger("adi_iio_node"),
         "read device attribute \"%s\" from device \"%s\" with value \"%s\"",
         iio_path.getDeviceAttrSegment().c_str(), iio_path.getDeviceSegment().c_str(), attr_val);
     } else {
       result = strerror(-ret1);
       ret = false;
       RCLCPP_WARN(
-        rclcpp::get_logger("rclcpp"),
+        rclcpp::get_logger("adi_iio_node"),
         "could not read attribute \"%s\" in device \"%s\" - errno %d - %s",
         iio_path.getDeviceAttrSegment().c_str(),
         iio_path.getDeviceSegment().c_str(), ret1, result.c_str());
@@ -157,7 +157,7 @@ bool IIONode::rwAttrPath(std::string path, std::string & result, bool write, std
     dev = iio_context_find_device(m_ctx, iio_path.getDeviceSegment().c_str());
     if (!dev) {
       RCLCPP_WARN(
-        rclcpp::get_logger("rclcpp"), "could not find device \"%s\"",
+        rclcpp::get_logger("adi_iio_node"), "could not find device \"%s\"",
         iio_path.getDeviceSegment().c_str());
       return ret;
     }
@@ -174,7 +174,7 @@ bool IIONode::rwAttrPath(std::string path, std::string & result, bool write, std
 
     if (!ch) {
       RCLCPP_WARN(
-        rclcpp::get_logger("rclcpp"), "could not find channel \"%s\"",
+        rclcpp::get_logger("adi_iio_node"), "could not find channel \"%s\"",
         iio_path.getChannelSegment().c_str());
       return ret;
     }
@@ -183,7 +183,7 @@ bool IIONode::rwAttrPath(std::string path, std::string & result, bool write, std
       ret1 = iio_channel_attr_write(ch, iio_path.getChannelAttrSegment().c_str(), value.c_str());
       if (ret1 > 0) {
         RCLCPP_INFO(
-          rclcpp::get_logger("rclcpp"),
+          rclcpp::get_logger("adi_iio_node"),
           "wrote channel attribute \"%s\" from channel \"%s\" device \"%s\" with value \"%s\"",
           iio_path.getChannelAttrSegment().c_str(),
           iio_path.getChannelSegment().c_str(), iio_path.getDeviceSegment().c_str(), value.c_str());
@@ -206,7 +206,7 @@ bool IIONode::rwAttrPath(std::string path, std::string & result, bool write, std
       result = attr_val;
       ret = true;
       RCLCPP_INFO(
-        rclcpp::get_logger("rclcpp"),
+        rclcpp::get_logger("adi_iio_node"),
         "read channel attribute \"%s\" from channel \"%s\" device \"%s\" with value \"%s\"",
         iio_path.getChannelAttrSegment().c_str(), iio_path.getChannelSegment().c_str(),
         iio_path.getDeviceSegment().c_str(), attr_val);
@@ -214,7 +214,7 @@ bool IIONode::rwAttrPath(std::string path, std::string & result, bool write, std
       result = strerror(-ret1);
       ret = false;
       RCLCPP_WARN(
-        rclcpp::get_logger("rclcpp"),
+        rclcpp::get_logger("adi_iio_node"),
         "could not read attribute \"%s\" from channel \"%s\" device \"%s\" - errno %d - %s",
         iio_path.getChannelAttrSegment().c_str(), iio_path.getChannelSegment().c_str(),
         iio_path.getDeviceSegment().c_str(), ret1, result.c_str());
@@ -232,7 +232,7 @@ void IIONode::attrReadSrv(
   std::shared_ptr<adi_iio::srv::AttrReadString::Response> response)
 {
   RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"), "Service request /AttrReadString : %s",
+    rclcpp::get_logger("adi_iio_node"), "Service request /AttrReadString : %s",
     request->attr_path.c_str());
   std::string result;
   response->success = rwAttrPath(request->attr_path, result);
@@ -244,7 +244,7 @@ void IIONode::attrWriteSrv(
   std::shared_ptr<adi_iio::srv::AttrWriteString::Response> response)
 {
   RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"), "Service request /AttrWriteString : %s value %s",
+    rclcpp::get_logger("adi_iio_node"), "Service request /AttrWriteString : %s value %s",
     request->attr_path.c_str(), request->value.c_str());
   std::string result;
   response->success = rwAttrPath(request->attr_path, result, true, request->value);
@@ -256,7 +256,7 @@ void IIONode::attrEnableTopicSrv(
   std::shared_ptr<adi_iio::srv::AttrEnableTopic::Response> response)
 {
   RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"),
+    rclcpp::get_logger("adi_iio_node"),
     "Service request /AttrEnableTopic %s with type %s with loop_rate %d Hz",
     request->attr_path.c_str(), request->attr_path.c_str(), request->loop_rate);
 
@@ -292,7 +292,7 @@ void IIONode::attrDisableTopicSrv(
   std::shared_ptr<adi_iio::srv::AttrDisableTopic::Response> response)
 {
   RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"), "Service request /AttrDisableTopic %s ",
+    rclcpp::get_logger("adi_iio_node"), "Service request /AttrDisableTopic %s ",
     request->topic_name.c_str());
 
   std::string message;
@@ -315,7 +315,7 @@ void IIONode::buffRefillSrv(
   std::shared_ptr<adi_iio::srv::BufferRefill::Response> response)
 {
   RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"), "Service request /BufferRill %s",
+    rclcpp::get_logger("adi_iio_node"), "Service request /BufferRill %s",
     request->device_path.c_str());
 
   std::string message;
@@ -357,7 +357,7 @@ void IIONode::buffReadSrv(
   }
 
   RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"), "Service request /BufferRead %s - %s - %d samples",
+    rclcpp::get_logger("adi_iio_node"), "Service request /BufferRead %s - %s - %d samples",
     request->device_path.c_str(), channels.c_str(), request->samples_count);
 
   std::string message;
@@ -407,7 +407,7 @@ void IIONode::buffWriteSrv(
   }
 
   RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"), "Service request /BufferWrite %s - %s - %d samples",
+    rclcpp::get_logger("adi_iio_node"), "Service request /BufferWrite %s - %s - %d samples",
     request->device_path.c_str(), channels.c_str(), request->buffer.layout.dim[0].size);
 
   std::string message;
@@ -455,7 +455,7 @@ void IIONode::buffCreateSrv(
   }
 
   RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"),
+    rclcpp::get_logger("adi_iio_node"),
     "Service request /BufferCreate %s - %s - %d samples",
     request->device_path.c_str(), channels.c_str(), request->samples_count);
 
@@ -493,7 +493,7 @@ void IIONode::buffDestroySrv(
   std::shared_ptr<adi_iio::srv::BufferDestroy::Response> response)
 {
   RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"),
+    rclcpp::get_logger("adi_iio_node"),
     "Service request /BufferDestroy %s", request->device_path.c_str());
 
   std::string msg;
@@ -523,7 +523,7 @@ void IIONode::buffEnableTopicSrv(
   std::shared_ptr<adi_iio::srv::BufferEnableTopic::Response> response)
 {
   RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"),
+    rclcpp::get_logger("adi_iio_node"),
     "Service request /BufferEnableTopic %s", request->device_path.c_str());
 
   std::string msg;
@@ -550,7 +550,7 @@ void IIONode::buffDisableTopicSrv(
   std::shared_ptr<adi_iio::srv::BufferDisableTopic::Response> response)
 {
   RCLCPP_INFO(
-    rclcpp::get_logger("rclcpp"),
+    rclcpp::get_logger("adi_iio_node"),
     "Service request /BufferDisableTopic %s", request->device_path.c_str());
 
   std::string msg;
@@ -576,7 +576,7 @@ void IIONode::listDevicesSrv(
   const std::shared_ptr<adi_iio::srv::ListDevices::Request> request,
   std::shared_ptr<adi_iio::srv::ListDevices::Response> response)
 {
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Service request /ListDevices");
+  RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "Service request /ListDevices");
   std::string msg;
 
   IIOPath path("");
@@ -598,7 +598,7 @@ void IIONode::listChannelsSrv(
   const std::shared_ptr<adi_iio::srv::ListChannels::Request> request,
   std::shared_ptr<adi_iio::srv::ListChannels::Response> response)
 {
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Service request /ListChannels");
+  RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "Service request /ListChannels");
   std::string msg;
 
   IIOPath path(request->iio_path);
@@ -635,7 +635,7 @@ void IIONode::listAttributesSrv(
   const std::shared_ptr<adi_iio::srv::ListAttributes::Request> request,
   std::shared_ptr<adi_iio::srv::ListAttributes::Response> response)
 {
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Service request /ListAttributes");
+  RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "Service request /ListAttributes");
   std::string msg;
   std::vector<std::string> data;
 
@@ -720,7 +720,7 @@ void IIONode::scanContextSrv(
   const std::shared_ptr<adi_iio::srv::ScanContext::Request> request,
   std::shared_ptr<adi_iio::srv::ScanContext::Response> response)
 {
-  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Service request /ScanContext");
+  RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "Service request /ScanContext");
   std::string msg{"Found: "};
   std::vector<std::string> devices;
   std::vector<std::string> channels;

--- a/src/iio_node.cpp
+++ b/src/iio_node.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "adi_iio/iio_node.hpp"
+#include "adi_iio/iio_path.hpp"
 #include "adi_iio/iio_attr_topic.hpp"
 #include "adi_iio/iio_buffer.hpp"
 #include <memory>

--- a/src/iio_node.cpp
+++ b/src/iio_node.cpp
@@ -519,6 +519,27 @@ void IIONode::buffDisableTopicSrv(
     response->message = "Buffer not found";
   }
 }
+std::vector<iio_device *> IIONode::getDevices(iio_context * ctx)
+{
+  std::vector<iio_device *> devices;
+  unsigned int devices_count = iio_context_get_devices_count(ctx);
+  for (unsigned int i = 0; i < devices_count; i++) {
+    iio_device * dev = iio_context_get_device(ctx, i);
+    devices.push_back(dev);
+  }
+  return devices;
+}
+
+std::vector<iio_channel *> IIONode::getChannels(iio_device * device)
+{
+  std::vector<iio_channel *> channels;
+  unsigned int channels_count = iio_device_get_channels_count(device);
+  for (unsigned int i = 0; i < channels_count; i++) {
+    iio_channel * ch = iio_device_get_channel(device, i);
+    channels.push_back(ch);
+  }
+  return channels;
+}
 
 std::string IIONode::uri()
 {

--- a/src/iio_node.cpp
+++ b/src/iio_node.cpp
@@ -579,6 +579,81 @@ void IIONode::listChannelsSrv(
   response->data = {data};
 }
 
+void IIONode::listAttributesSrv(
+  const std::shared_ptr<adi_iio::srv::ListAttributes::Request> request,
+  std::shared_ptr<adi_iio::srv::ListAttributes::Response> response)
+{
+  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Service request: /ListAttributes");
+  std::string msg;
+  std::vector<std::string> data;
+
+  IIOPath path(request->iio_path);
+  if (path.isValid(IIOPathType::CONTEXT)) {
+    int ret{};
+    std::string err_str;
+
+    unsigned int nb_ctx_attrs = iio_context_get_attrs_count(ctx());
+    for (unsigned int i = 0; i < nb_ctx_attrs; i++) {
+      const char * key, * value;
+
+      ret = iio_context_get_attr(ctx(), i, &key, &value);
+      if (ret == 0) {
+        data.push_back(path.append(std::string(key)));
+      } else {
+        err_str = strerror(-ret);
+        RCLCPP_WARN(
+          rclcpp::get_logger(
+            "rclcpp"), "Unable to read IIO context attribute: %s", err_str.c_str());
+      }
+    }
+    msg = "Found " + std::to_string(data.size()) + " attributes";
+  } else if (path.isValid(IIOPathType::DEVICE)) {
+    auto dev_name = path.getDeviceSegment();
+    iio_device * dev = iio_context_find_device(ctx(), dev_name.c_str());
+    if (dev == nullptr) {
+      msg = "Could not find device: " + dev_name;
+      setWarningResponse(response, msg);
+      return;
+    }
+
+    unsigned int nb_attrs = iio_device_get_attrs_count(dev);
+    for (unsigned int i = 0; i < nb_attrs; i++) {
+      std::string attr_key = iio_device_get_attr(dev, i);
+      data.push_back(path.append(attr_key));
+    }
+    msg = "Found " + std::to_string(data.size()) + " attributes in device: " + dev_name;
+  } else if (path.isValid(IIOPathType::CHANNEL)) {
+    auto dev_name = path.getDeviceSegment();
+    iio_device * dev = iio_context_find_device(ctx(), dev_name.c_str());
+    if (dev == nullptr) {
+      msg = "Could not find device: " + dev_name;
+      setWarningResponse(response, msg);
+      return;
+    }
+
+    auto [is_output, chn_name] = path.getExtendedChannelSegment();
+    iio_channel * chn = iio_device_find_channel(dev, chn_name.c_str(), is_output);
+    if (chn == nullptr) {
+      msg = "Could not find channel: " + chn_name;
+      setWarningResponse(response, msg);
+      return;
+    }
+    unsigned int nb_attrs = iio_channel_get_attrs_count(chn);
+    for (unsigned int i = 0; i < nb_attrs; i++) {
+      std::string attr_key = iio_channel_get_attr(chn, i);
+      data.push_back(path.append(attr_key));
+    }
+    msg = "Found " + std::to_string(data.size()) + " attributes in channel: " + chn_name;
+  } else {
+    msg = "Invalid path: " + request->iio_path;
+    setErrorResponse(response, msg);
+    return;
+  }
+
+  setSuccessResponse(response, msg);
+  response->data = {data};
+}
+
 
 std::vector<iio_device *> IIONode::getDevices(iio_context * ctx)
 {

--- a/src/iio_node.cpp
+++ b/src/iio_node.cpp
@@ -654,6 +654,83 @@ void IIONode::listAttributesSrv(
   response->data = {data};
 }
 
+void IIONode::scanContextSrv(
+  const std::shared_ptr<adi_iio::srv::ScanContext::Request> request,
+  std::shared_ptr<adi_iio::srv::ScanContext::Response> response)
+{
+  RCLCPP_INFO(rclcpp::get_logger("rclcpp"), "Service request: /ScanContext");
+  std::string msg{"Found: "};
+  std::vector<std::string> devices;
+  std::vector<std::string> channels;
+  std::vector<std::string> context_attrs;
+  std::vector<std::string> device_attrs;
+  std::vector<std::string> channel_attrs;
+
+  // Handle context attributes
+  IIOPath ctx_path("");
+  int ret{};
+  std::string err_str;
+  unsigned int nb_ctx_attrs = iio_context_get_attrs_count(ctx());
+  for (unsigned int i = 0; i < nb_ctx_attrs; i++) {
+    const char * key, * value;
+    ret = iio_context_get_attr(ctx(), i, &key, &value);
+    if (ret == 0) {
+      context_attrs.push_back(ctx_path.append(std::string(key)));
+    } else {
+      err_str = strerror(-ret);
+      RCLCPP_WARN(
+        rclcpp::get_logger(
+          "rclcpp"),
+        "Unable to read IIO context attribute: %s", err_str.c_str());
+    }
+  }
+
+  // Handle devices
+  auto devices_ptr = getDevices(ctx());
+  for (iio_device * dev : devices_ptr) {
+    auto dev_name = std::string(iio_device_get_name(dev));
+    auto dev_path = IIOPath(ctx_path.append(dev_name));
+
+    devices.push_back(dev_path.basePath());
+
+    // Handle device attributes
+    unsigned int nb_attrs = iio_device_get_attrs_count(dev);
+    for (unsigned int i = 0; i < nb_attrs; i++) {
+      std::string attr_key = iio_device_get_attr(dev, i);
+      device_attrs.push_back(dev_path.append(attr_key));
+    }
+
+    // Handle device channels
+    auto channels_ptr = getChannels(dev);
+    for (iio_channel * chn : channels_ptr) {
+      auto chn_name = std::string(iio_channel_get_id(chn));
+      auto is_output = iio_channel_is_output(chn);
+      auto chn_segment = IIOPath::toExtendedChannelSegment(is_output, chn_name);
+      auto chn_path = IIOPath(dev_path.append(chn_segment));
+
+      channels.push_back(chn_path.basePath());
+
+      // Handle channel attributes
+      unsigned int nb_attrs = iio_channel_get_attrs_count(chn);
+      for (unsigned int i = 0; i < nb_attrs; i++) {
+        std::string attr_key = iio_channel_get_attr(chn, i);
+        channel_attrs.push_back(chn_path.append(attr_key));
+      }
+    }
+  }
+  msg += "Context attributes: " + std::to_string(context_attrs.size()) + "; ";
+  msg += "Devices: " + std::to_string(devices.size()) + "; ";
+  msg += "Channels: " + std::to_string(channels.size()) + "; ";
+  msg += "Device attributes: " + std::to_string(device_attrs.size()) + "; ";
+  msg += "Channel attributes: " + std::to_string(channel_attrs.size()) + "; ";
+
+  setSuccessResponse(response, msg);
+  response->devices = {devices};
+  response->channels = {channels};
+  response->context_attrs = {context_attrs};
+  response->device_attrs = {device_attrs};
+  response->channel_attrs = {channel_attrs};
+}
 
 std::vector<iio_device *> IIONode::getDevices(iio_context * ctx)
 {

--- a/src/iio_node.cpp
+++ b/src/iio_node.cpp
@@ -542,6 +542,44 @@ void IIONode::listDevicesSrv(
   response->data = {data};
 }
 
+void IIONode::listChannelsSrv(
+  const std::shared_ptr<adi_iio::srv::ListChannels::Request> request,
+  std::shared_ptr<adi_iio::srv::ListChannels::Response> response)
+{
+  RCLCPP_DEBUG(rclcpp::get_logger("rclcpp"), "Service request: /ListChannels");
+  std::string msg;
+
+  IIOPath path(request->iio_path);
+  if (!path.isValid(IIOPathType::DEVICE)) {
+    msg = "Invalid path: " + request->iio_path;
+    setWarningResponse(response, msg);
+    return;
+  }
+
+  auto dev_name = path.getDeviceSegment();
+  iio_device * dev = iio_context_find_device(ctx(), dev_name.c_str());
+  if (dev == nullptr) {
+    msg = "Could not find device: " + dev_name;
+    setWarningResponse(response, msg);
+    return;
+  }
+
+  std::vector<std::string> data;
+
+  auto channels_ptr = getChannels(dev);
+  for (iio_channel * chn : channels_ptr) {
+    auto chn_name = std::string(iio_channel_get_id(chn));
+    auto is_output = iio_channel_is_output(chn);
+    auto chn_path = IIOPath::toExtendedChannelSegment(is_output, chn_name);
+    data.push_back(path.append(chn_path));
+  }
+
+  msg = "Found " + std::to_string(data.size()) + " channels in device: " + dev_name;
+  setSuccessResponse(response, msg);
+  response->data = {data};
+}
+
+
 std::vector<iio_device *> IIONode::getDevices(iio_context * ctx)
 {
   std::vector<iio_device *> devices;

--- a/src/iio_node.cpp
+++ b/src/iio_node.cpp
@@ -576,6 +576,7 @@ void IIONode::listDevicesSrv(
   const std::shared_ptr<adi_iio::srv::ListDevices::Request> request,
   std::shared_ptr<adi_iio::srv::ListDevices::Response> response)
 {
+  (void) request; // unused
   RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "Service request /ListDevices");
   std::string msg;
 
@@ -720,6 +721,7 @@ void IIONode::scanContextSrv(
   const std::shared_ptr<adi_iio::srv::ScanContext::Request> request,
   std::shared_ptr<adi_iio::srv::ScanContext::Response> response)
 {
+  (void) request; // unused
   RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "Service request /ScanContext");
   std::string msg{"Found: "};
   std::vector<std::string> devices;

--- a/src/iio_path.cpp
+++ b/src/iio_path.cpp
@@ -1,0 +1,120 @@
+// Copyright 2025 Analog Devices, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "adi_iio/iio_path.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <string>
+
+
+IIOPath::IIOPath(std::string path, char delimiter)
+{
+  m_base_path = path;
+  m_delimiter = delimiter;
+
+  m_segments = split(path);
+}
+
+std::string IIOPath::basePath() const
+{
+  return m_base_path;
+}
+
+std::string IIOPath::getContextAttrSegment() const
+{
+  return m_segments[0];
+}
+
+std::string IIOPath::getDeviceSegment() const
+{
+  return m_segments[0];
+}
+
+std::string IIOPath::getDeviceAttrSegment() const
+{
+  return m_segments[1];
+}
+
+std::string IIOPath::getChannelSegment() const
+{
+  return m_segments[1];
+}
+
+std::pair<bool, std::string> IIOPath::getExtendedChannelSegment() const
+{
+  auto chn_segment = getChannelSegment();
+  bool hasPrefix = chn_segment.find("input_") == 0 || chn_segment.find("output_") == 0;
+  if (!hasPrefix) {
+    return {false, ""};
+  }
+
+  std::string prefix = chn_segment.substr(0, chn_segment.find('_'));
+  std::string chn_name = chn_segment.substr(chn_segment.find('_') + 1);
+
+  bool output = prefix == "output";
+  return {output, chn_name};
+}
+
+std::string IIOPath::getChannelAttrSegment() const
+{
+  return m_segments[2];
+}
+
+std::string IIOPath::append(const std::string & suffix)
+{
+  if (m_base_path.empty()) {
+    return suffix;
+  }
+  return m_base_path + m_delimiter + suffix;
+}
+
+bool IIOPath::isValid(const IIOPathType type)
+{
+  switch (type) {
+    case CONTEXT:
+      return m_segments.size() == 0 && m_base_path.empty();
+    case CONTEXT_ATTR:
+      return m_segments.size() == 1 && !getContextAttrSegment().empty();
+    case DEVICE:
+      return m_segments.size() == 1 && !getDeviceSegment().empty();
+    case DEVICE_ATTR:
+      return m_segments.size() == 2 && !getDeviceAttrSegment().empty();
+    case CHANNEL:
+      return m_segments.size() == 2 && !getExtendedChannelSegment().second.empty();
+    case CHANNEL_ATTR:
+      return m_segments.size() == 3 && !getChannelAttrSegment().empty();
+    default:
+      RCLCPP_WARN(rclcpp::get_logger("rclcpp"), "Invalid path type");
+      return false;
+  }
+}
+
+std::string IIOPath::toExtendedChannelSegment(bool output, std::string chn_name)
+{
+  std::string prefix = output ? "output_" : "input_";
+  return prefix + chn_name;
+}
+
+std::vector<std::string> IIOPath::split(const std::string & str)
+{
+  std::vector<std::string> segments;
+  std::stringstream ss(str);
+  std::string segment;
+
+  while (std::getline(ss, segment, m_delimiter)) {
+    segments.push_back(segment);
+  }
+  return segments;
+}

--- a/src/iio_path.cpp
+++ b/src/iio_path.cpp
@@ -55,16 +55,19 @@ std::string IIOPath::getChannelSegment() const
 std::pair<bool, std::string> IIOPath::getExtendedChannelSegment() const
 {
   auto chn_segment = getChannelSegment();
-  bool hasPrefix = chn_segment.find("input_") == 0 || chn_segment.find("output_") == 0;
-  if (!hasPrefix) {
-    return {false, ""};
-  }
 
   std::string prefix = chn_segment.substr(0, chn_segment.find('_'));
   std::string chn_name = chn_segment.substr(chn_segment.find('_') + 1);
 
   bool output = prefix == "output";
   return {output, chn_name};
+}
+
+bool IIOPath::hasExtendedChannelFormat() const
+{
+  auto chn_segment = getChannelSegment();
+  bool hasPrefix = chn_segment.find("input_") == 0 || chn_segment.find("output_") == 0;
+  return hasPrefix;
 }
 
 std::string IIOPath::getChannelAttrSegment() const
@@ -105,6 +108,12 @@ std::string IIOPath::toExtendedChannelSegment(bool output, std::string chn_name)
 {
   std::string prefix = output ? "output_" : "input_";
   return prefix + chn_name;
+}
+
+std::string IIOPath::toTopicName(std::string path)
+{
+  std::replace(path.begin(), path.end(), '-', '_');
+  return path;
 }
 
 std::vector<std::string> IIOPath::split(const std::string & str)

--- a/src/iio_path.cpp
+++ b/src/iio_path.cpp
@@ -99,7 +99,7 @@ bool IIOPath::isValid(const IIOPathType type)
     case CHANNEL_ATTR:
       return m_segments.size() == 3 && !getChannelAttrSegment().empty();
     default:
-      RCLCPP_WARN(rclcpp::get_logger("rclcpp"), "Invalid path type");
+      RCLCPP_WARN(rclcpp::get_logger("adi_iio_node"), "Invalid path type");
       return false;
   }
 }

--- a/srv/AttrDisableTopic.srv
+++ b/srv/AttrDisableTopic.srv
@@ -1,34 +1,10 @@
-################################################################################
-# @file   AttrDisableTopic.srv
-# @author Adrian-Stanea (Adrian.Stanea@analog.com)
-#
-# SPDX-License-Identifier: Apache-2.0 (see LICENSE file)
-# Copyright (c) 2025 Analog Devices, Inc.
-################################################################################
-#
-# Description:
-#   Disables a topic for a specific attribute.
-#
-# Request:
-#   attr_path (string):
-#       - Description: The path to the attribute to be disabled.
-#
-# Response:
-#   success (boolean):
-#       - Description: Indicates if the operation was successful.
-#   message (string):
-#       - Description: Provides additional information.
-#
-################################################################################
-
-
 int8 STRING = 0
 int8 INT = 1
 int8 DOUBLE = 2
 int8 BOOL = 3
 
 string topic_name
-int8 type 0
+int8 type 0 # String: 0, Int: 1, Double: 2, Bool: 3
 ---
 bool success
 string message

--- a/srv/AttrEnableTopic.srv
+++ b/srv/AttrEnableTopic.srv
@@ -1,27 +1,3 @@
-################################################################################
-# @file   AttrEnableTopic.srv
-# @author Adrian-Stanea (Adrian.Stanea@analog.com)
-#
-# SPDX-License-Identifier: Apache-2.0 (see LICENSE file)
-# Copyright (c) 2025 Analog Devices, Inc.
-################################################################################
-#
-# Description:
-#   Enables a topic for a specific attribute.
-#
-# Request:
-#   attr_path (string):
-#       - Description: The path to the attribute to be enabled.
-#
-# Response:
-#   success (boolean):
-#       - Description: Indicates if the operation was successful.
-#   message (string):
-#       - Description: Provides additional information.
-#
-################################################################################
-
-
 int8 STRING = 0
 int8 INT = 1
 int8 DOUBLE = 2
@@ -30,7 +6,7 @@ int8 BOOL = 3
 string attr_path
 string topic_name ""
 int32 loop_rate 1
-int8 type 0
+int8 type 0 # String: 0, Int: 1, Double: 2, Bool: 3
 ---
 bool success
 string message

--- a/srv/AttrReadString.srv
+++ b/srv/AttrReadString.srv
@@ -1,29 +1,3 @@
-################################################################################
-# @file   AttrReadString.srv
-# @author Adrian-Stanea (Adrian.Stanea@analog.com)
-#
-# SPDX-License-Identifier: Apache-2.0 (see LICENSE file)
-# Copyright (c) 2025 Analog Devices, Inc.
-################################################################################
-#
-# Description:
-#   Reads an IIO attribute as a string.
-#
-# Request:
-#   attr_path (string):
-#       - Description: The path to the attribute to be read.
-#
-# Response:
-#   value (string):
-#       - Description: The value of the attribute.
-#   success (boolean):
-#       - Description: Indicates if the operation was successful.
-#   message (string):
-#       - Description: Provides additional information.
-#
-################################################################################
-
-
 string attr_path
 ---
 bool success

--- a/srv/AttrWriteString.srv
+++ b/srv/AttrWriteString.srv
@@ -1,29 +1,3 @@
-################################################################################
-# @file   AttrWriteString.srv
-# @author Adrian-Stanea (Adrian.Stanea@analog.com)
-#
-# SPDX-License-Identifier: Apache-2.0 (see LICENSE file)
-# Copyright (c) 2025 Analog Devices, Inc.
-################################################################################
-#
-# Description:
-#   Writes an IIO attribute as a string.
-#
-# Request:
-#   attr_path (string):
-#       - Description: The path to the attribute to be written.
-#   value (string):
-#       - Description: The value to be written to the attribute.
-#
-# Response:
-#   success (boolean):
-#       - Description: Indicates if the operation was successful.
-#   message (string):
-#       - Description: Provides additional information.
-#
-################################################################################
-
-
 string attr_path
 string value
 ---

--- a/srv/BufferCreate.srv
+++ b/srv/BufferCreate.srv
@@ -1,31 +1,3 @@
-################################################################################
-# @file   BufferCreate.srv
-# @author Adrian-Stanea (Adrian.Stanea@analog.com)
-#
-# SPDX-License-Identifier: Apache-2.0 (see LICENSE file)
-# Copyright (c) 2025 Analog Devices, Inc.
-################################################################################
-#
-# Description:
-#   Creates a buffer.
-#
-# Request:
-#   device_path (string):
-#       - Description: The path to the device.
-#   channels (string[]):
-#       - Description: The channels to be included in the buffer.
-#   samples_count (int):
-#       - Description: The number of samples for the buffer.
-#
-# Response:
-#   success (boolean):
-#       - Description: Indicates if the operation was successful.
-#   message (string):
-#       - Description: Provides additional information.
-#
-################################################################################
-
-
 string device_path
 string[] channels
 int32 samples_count

--- a/srv/BufferDestroy.srv
+++ b/srv/BufferDestroy.srv
@@ -1,27 +1,3 @@
-################################################################################
-# @file   BufferDestroy.srv
-# @author Adrian-Stanea (Adrian.Stanea@analog.com)
-#
-# SPDX-License-Identifier: Apache-2.0 (see LICENSE file)
-# Copyright (c) 2025 Analog Devices, Inc.
-################################################################################
-#
-# Description:
-#   Destroys a buffer.
-#
-# Request:
-#   device_path (string):
-#       - Description: The path to the device.
-#
-# Response:
-#   success (boolean):
-#       - Description: Indicates if the operation was successful.
-#   message (string):
-#       - Description: Provides additional information.
-#
-################################################################################
-
-
 string device_path
 ---
 bool success

--- a/srv/BufferDisableTopic.srv
+++ b/srv/BufferDisableTopic.srv
@@ -1,29 +1,3 @@
-################################################################################
-# @file   BufferDisableTopic.srv
-# @author Adrian-Stanea (Adrian.Stanea@analog.com)
-#
-# SPDX-License-Identifier: Apache-2.0 (see LICENSE file)
-# Copyright (c) 2025 Analog Devices, Inc.
-################################################################################
-#
-# Description:
-#   Disables a topic for a buffer.
-#
-# Request:
-#   device_path (string):
-#       - Description: The path to the device.
-#   topic (string):
-#       - Description: The topic to be disabled.
-#
-# Response:
-#   success (boolean):
-#       - Description: Indicates if the operation was successful.
-#   message (string):
-#       - Description: Provides additional information.
-#
-################################################################################
-
-
 string device_path
 ---
 bool success

--- a/srv/BufferEnableTopic.srv
+++ b/srv/BufferEnableTopic.srv
@@ -1,29 +1,3 @@
-################################################################################
-# @file   BufferEnableTopic.srv
-# @author Adrian-Stanea (Adrian.Stanea@analog.com)
-#
-# SPDX-License-Identifier: Apache-2.0 (see LICENSE file)
-# Copyright (c) 2025 Analog Devices, Inc.
-################################################################################
-#
-# Description:
-#   Enables a topic for a buffer.
-#
-# Request:
-#   device_path (string):
-#       - Description: The path to the device.
-#   topic_name (string):
-#       - Description: The topic to be enabled.
-#
-# Response:
-#   success (boolean):
-#       - Description: Indicates if the operation was successful.
-#   message (string):
-#       - Description: Provides additional information.
-#
-################################################################################
-
-
 string device_path
 string topic_name
 ---

--- a/srv/BufferRead.srv
+++ b/srv/BufferRead.srv
@@ -1,31 +1,3 @@
-################################################################################
-# @file   BufferRead.srv
-# @author Adrian-Stanea (Adrian.Stanea@analog.com)
-#
-# SPDX-License-Identifier: Apache-2.0 (see LICENSE file)
-# Copyright (c) 2025 Analog Devices, Inc.
-################################################################################
-#
-# Description:
-#   Reads data from a buffer.
-#
-# Request:
-#   device_path (string):
-#       - Description: The path to the device.
-#   samples_count (int):
-#       - Description: The number of samples to read.
-#
-# Response:
-#   success (boolean):
-#       - Description: Indicates if the operation was successful.
-#   message (string):
-#       - Description: Provides additional information.
-#   buffer (Int32MultiArray):
-#       - Description: The data read from the buffer.
-#
-################################################################################
-
-
 string device_path
 string[] channels
 int32 samples_count

--- a/srv/BufferRefill.srv
+++ b/srv/BufferRefill.srv
@@ -1,29 +1,3 @@
-################################################################################
-# @file   BufferRefill.srv
-# @author Adrian-Stanea (Adrian.Stanea@analog.com)
-#
-# SPDX-License-Identifier: Apache-2.0 (see LICENSE file)
-# Copyright (c) 2025 Analog Devices, Inc.
-################################################################################
-#
-# Description:
-#   Refills a buffer.
-#
-# Request:
-#   device_path (string):
-#       - Description: The path to the device.
-#
-# Response:
-#   success (boolean):
-#       - Description: Indicates if the operation was successful.
-#   message (string):
-#       - Description: Provides additional information.
-#   buffer (Int32MultiArray):
-#       - Description: The data read from the buffer after refilling.
-#
-################################################################################
-
-
 string device_path
 ---
 bool success

--- a/srv/BufferWrite.srv
+++ b/srv/BufferWrite.srv
@@ -1,29 +1,3 @@
-################################################################################
-# @file   BufferWrite.srv
-# @author Adrian-Stanea (Adrian.Stanea@analog.com)
-#
-# SPDX-License-Identifier: Apache-2.0 (see LICENSE file)
-# Copyright (c) 2025 Analog Devices, Inc.
-################################################################################
-#
-# Description:
-#   Writes data to a buffer.
-#
-# Request:
-#   device_path (string):
-#       - Description: The path to the device.
-#   buffer (Int32MultiArray):
-#       - Description: The data to be written to the buffer.
-#
-# Response:
-#   success (boolean):
-#       - Description: Indicates if the operation was successful.
-#   message (string):
-#       - Description: Provides additional information.
-#
-################################################################################
-
-
 string device_path
 string[] channels
 std_msgs/Int32MultiArray buffer

--- a/srv/ListAttributes.srv
+++ b/srv/ListAttributes.srv
@@ -1,0 +1,5 @@
+string iio_path # A valid IIO path to a context/device/channel
+---
+bool success
+string message
+string[] data

--- a/srv/ListChannels.srv
+++ b/srv/ListChannels.srv
@@ -1,0 +1,5 @@
+string iio_path # A valid IIO path to a device
+---
+bool success
+string message
+string[] data

--- a/srv/ListDevices.srv
+++ b/srv/ListDevices.srv
@@ -1,0 +1,4 @@
+---
+bool success
+string message
+string[] data

--- a/srv/ScanContext.srv
+++ b/srv/ScanContext.srv
@@ -1,0 +1,8 @@
+---
+bool success
+string message
+string[] devices
+string[] channels
+string[] context_attrs
+string[] device_attrs
+string[] channel_attrs


### PR DESCRIPTION
- [x] List Devices
- [x] List Channels
- [x] List Attributes (context attr, device attr, channel attr)
- [x] Scan IIO context (similar to iio_info)

Each service returns an `IIOPath` which is a unique identifier that can be used in subsequent listing services: (e.g.: given an IIOPath to a device we can call the ListChannels service which will return IIOPaths to channels. These paths can later be used for example in the ListAttr service to list channel attributes)