### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,22 +5,32 @@ env:
   PACKAGE_NAME: "adi_iio"
 
 on:
-  push:
-    branches: [ "*", "ci*"]
-    tags: [ "v*" ]
-  pull_request:
-    branches: [ "humble", "humble-develop", "main" ]
-  # Allow manual triggering from the GitHub UI
   workflow_dispatch:
+  pull_request:
+  merge_group:
+  push:
+    branches:
+      - rolling
+      - rolling-develop
+      - main
 
 jobs:
   build-package:
-    name: ROS ${{ matrix.ROS_DISTRIBUTION }}
-    runs-on: ubuntu-22.04
+    name: ROS ${{ matrix.ros_distribution }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRIBUTION: [humble]
+        ros_distribution:
+          - rolling
+        include:
+          # Rolling Ridley (No End-Of-Life)
+          - docker_image: ubuntu:noble
+            ros_distribution: rolling
+            ros_version: 2
+
+    container:
+      image: ${{ matrix.docker_image }}
 
     steps:
       - name: Setup workspace
@@ -38,7 +48,7 @@ jobs:
       - name: Setup ROS environment
         uses: ros-tooling/setup-ros@v0.7
         with:
-          required-ros-distributions: ${{ matrix.ROS_DISTRIBUTION }}
+          required-ros-distributions: ${{ matrix.ros_distribution }}
           use-ros2-testing: false
 
       - name: Build the package
@@ -46,7 +56,7 @@ jobs:
         uses: ros-tooling/action-ros-ci@v0.4
         with:
           package-name: ${{ env.PACKAGE_NAME }}
-          target-ros2-distro: ${{ matrix.ROS_DISTRIBUTION }}
+          target-ros2-distro: ${{ matrix.ros_distribution }}
           skip-tests: true # TODO: Enable tests if any (TBD)
           import-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,11 +11,13 @@ env:
 
 jobs:
   ament_lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRIBUTION: [humble]
+        ros_distribution:
+          # Rolling Ridley (No End-Of-Life)
+          - rolling
         linter:
           - cppcheck
           - uncrustify
@@ -32,7 +34,7 @@ jobs:
       - name: Setup ROS environment
         uses: ros-tooling/setup-ros@v0.7
         with:
-          required-ros-distributions: ${{ matrix.ROS_DISTRIBUTION }}
+          required-ros-distributions: ${{ matrix.ros_distribution }}
           use-ros2-testing: false
 
       - name: Run Linter
@@ -41,15 +43,18 @@ jobs:
         uses: ros-tooling/action-ros-lint@master
         with:
           linter: ${{ matrix.linter }}
-          distribution: ${{ matrix.ROS_DISTRIBUTION }}
+          distribution: ${{ matrix.ros_distribution }}
           package-name: ${{ env.PACKAGE_NAME }}
 
   pre_commit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        ROS_DISTRIBUTION: [humble]
+        ros_distribution:
+          # Rolling Ridley (No End-Of-Life)
+          - rolling
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -59,6 +64,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install pip packages
+        working-directory: ${{ github.workspace }}
         run: |
           pip install pip --upgrade
           pip install -r requirements.txt
@@ -66,12 +72,13 @@ jobs:
       - name: Setup ROS environment
         uses: ros-tooling/setup-ros@v0.7
         with:
-          required-ros-distributions: ${{ matrix.ROS_DISTRIBUTION }}
+          required-ros-distributions: ${{ matrix.ros_distribution }}
           use-ros2-testing: false
 
       - name: Run pre-commit-checks
+        working-directory: ${{ github.workspace }}
         run: |
-          source /opt/ros/${{ matrix.ROS_DISTRIBUTION }}/setup.sh
+          . /opt/ros/${{ matrix.ros_distribution }}/setup.sh
           make fix
           FIX_STATUS=$?
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ target_include_directories(${NODE_NAME}
               $<INSTALL_INTERFACE:include>)
 
 target_link_libraries(${NODE_NAME} ${IIO_LIBRARIES} "${adi_iio_srvs_typesupport_target}")
-ament_target_dependencies(${NODE_NAME} rclcpp std_msgs)
+target_link_libraries(${NODE_NAME} PUBLIC rclcpp std_msgs)
 ament_export_dependencies(rosidl_default_runtime)
 
 install(TARGETS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,8 +66,11 @@ target_include_directories(${NODE_NAME}
               $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
               $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(${NODE_NAME} ${IIO_LIBRARIES} "${adi_iio_srvs_typesupport_target}")
-target_link_libraries(${NODE_NAME} PUBLIC rclcpp std_msgs)
+target_link_libraries(${NODE_NAME} PUBLIC
+  ${IIO_LIBRARIES}
+  "${adi_iio_srvs_typesupport_target}"
+  ${std_msgs_TARGETS}
+  rclcpp::rclcpp)
 ament_export_dependencies(rosidl_default_runtime)
 
 install(TARGETS


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
