### PR TITLE
Fix IIO buffer throttling and parallelize service servers

### DIFF
--- a/include/adi_iio/iio_attr_topic.hpp
+++ b/include/adi_iio/iio_attr_topic.hpp
@@ -47,7 +47,7 @@ public:
 
   IIOAttrTopic(
     std::shared_ptr<IIONode> nh, std::string topicName, std::string attrPath,
-    topicType_t type, int loopRate);
+    topicType_t type, double loopRate);
   virtual ~IIOAttrTopic();
 
   void publishingLoop();

--- a/include/adi_iio/iio_buffer.hpp
+++ b/include/adi_iio/iio_buffer.hpp
@@ -42,7 +42,7 @@ public:
   bool refill(std::string & message);
   bool push(std::string & message, std_msgs::msg::Int32MultiArray & data);
 
-  void enableTopic(std::string topic_name, int loopRate);
+  void enableTopic(std::string topic_name, double loopRate);
   void disableTopic();
   void publishingLoop();
 

--- a/include/adi_iio/iio_buffer.hpp
+++ b/include/adi_iio/iio_buffer.hpp
@@ -42,7 +42,7 @@ public:
   bool refill(std::string & message);
   bool push(std::string & message, std_msgs::msg::Int32MultiArray & data);
 
-  void enableTopic(std::string topic_name);
+  void enableTopic(std::string topic_name, int loopRate);
   void disableTopic();
   void publishingLoop();
 
@@ -77,6 +77,7 @@ private:
   bool m_canceled;
   bool m_stopThread;
   std::mutex m_mutex;
+  std::shared_ptr<rclcpp::Rate> m_loopRate;
 };
 
 #endif  // ADI_IIO__IIO_BUFFER_HPP_

--- a/include/adi_iio/iio_node.hpp
+++ b/include/adi_iio/iio_node.hpp
@@ -155,6 +155,7 @@ protected:
 private:
   bool m_initialized;
   std::string m_uri;
+  int32_t m_timeout;
   iio_context * m_ctx;
 
   std::map<std::string, std::shared_ptr<IIOAttrTopic>> m_attrTopicMap;

--- a/src/adi_iio.cpp
+++ b/src/adi_iio.cpp
@@ -22,6 +22,7 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
 
   std::shared_ptr<IIONode> node = std::make_shared<IIONode>();
+  rclcpp::executors::MultiThreadedExecutor executor;
 
   if (!node->initialized()) {
     RCLCPP_FATAL(rclcpp::get_logger("adi_iio_node"), "Node initialization failed.");
@@ -30,84 +31,146 @@ int main(int argc, char ** argv)
 
   node->initBuffers();
 
+  auto cb_group_attr_read_string = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   rclcpp::Service<adi_iio::srv::AttrReadString>::SharedPtr attrReadSrv =
     node->create_service<adi_iio::srv::AttrReadString>(
     std::string(node->get_name()) + "/AttrReadString",
-    std::bind(&IIONode::attrReadSrv, node, std::placeholders::_1, std::placeholders::_2));
+    std::bind(&IIONode::attrReadSrv, node, std::placeholders::_1, std::placeholders::_2),
+    rmw_qos_profile_services_default,
+    cb_group_attr_read_string);
 
+  auto cb_group_attr_write_string = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   rclcpp::Service<adi_iio::srv::AttrWriteString>::SharedPtr attrWriteSrv =
     node->create_service<adi_iio::srv::AttrWriteString>(
     std::string(node->get_name()) + "/AttrWriteString",
-    std::bind(&IIONode::attrWriteSrv, node, std::placeholders::_1, std::placeholders::_2));
+    std::bind(&IIONode::attrWriteSrv, node, std::placeholders::_1, std::placeholders::_2),
+    rmw_qos_profile_services_default,
+    cb_group_attr_write_string);
 
+  auto cb_group_attr_enable_topic = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   rclcpp::Service<adi_iio::srv::AttrEnableTopic>::SharedPtr attrEnableTopicSrv =
     node->create_service<adi_iio::srv::AttrEnableTopic>(
     std::string(node->get_name()) + "/AttrEnableTopic",
-    std::bind(&IIONode::attrEnableTopicSrv, node, std::placeholders::_1, std::placeholders::_2));
+    std::bind(&IIONode::attrEnableTopicSrv, node, std::placeholders::_1, std::placeholders::_2),
+    rmw_qos_profile_services_default,
+    cb_group_attr_enable_topic);
 
+  auto cb_group_attr_disable_topic = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   rclcpp::Service<adi_iio::srv::AttrDisableTopic>::SharedPtr attrDisableTopicSrv =
     node->create_service<adi_iio::srv::AttrDisableTopic>(
     std::string(node->get_name()) + "/AttrDisableTopic",
-    std::bind(&IIONode::attrDisableTopicSrv, node, std::placeholders::_1, std::placeholders::_2));
+    std::bind(&IIONode::attrDisableTopicSrv, node, std::placeholders::_1, std::placeholders::_2),
+    rmw_qos_profile_services_default,
+    cb_group_attr_disable_topic);
 
+  auto cb_group_buffer_read = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   rclcpp::Service<adi_iio::srv::BufferRead>::SharedPtr buffReadSrv =
     node->create_service<adi_iio::srv::BufferRead>(
     std::string(node->get_name()) + "/BufferRead",
-    std::bind(&IIONode::buffReadSrv, node, std::placeholders::_1, std::placeholders::_2));
+    std::bind(&IIONode::buffReadSrv, node, std::placeholders::_1, std::placeholders::_2),
+    rmw_qos_profile_services_default,
+    cb_group_buffer_read);
 
+  auto cb_group_buffer_write = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   rclcpp::Service<adi_iio::srv::BufferWrite>::SharedPtr buffWriteSrv =
     node->create_service<adi_iio::srv::BufferWrite>(
     std::string(node->get_name()) + "/BufferWrite",
-    std::bind(&IIONode::buffWriteSrv, node, std::placeholders::_1, std::placeholders::_2));
+    std::bind(&IIONode::buffWriteSrv, node, std::placeholders::_1, std::placeholders::_2),
+    rmw_qos_profile_services_default,
+    cb_group_buffer_write);
 
+  auto cb_group_buffer_create = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   rclcpp::Service<adi_iio::srv::BufferCreate>::SharedPtr buffCreateSrv =
     node->create_service<adi_iio::srv::BufferCreate>(
     std::string(node->get_name()) + "/BufferCreate",
-    std::bind(&IIONode::buffCreateSrv, node, std::placeholders::_1, std::placeholders::_2));
+    std::bind(&IIONode::buffCreateSrv, node, std::placeholders::_1, std::placeholders::_2),
+    rmw_qos_profile_services_default,
+    cb_group_buffer_create);
 
+  auto cb_group_buffer_destroy = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   rclcpp::Service<adi_iio::srv::BufferDestroy>::SharedPtr buffDestroySrv =
     node->create_service<adi_iio::srv::BufferDestroy>(
     std::string(node->get_name()) + "/BufferDestroy",
-    std::bind(&IIONode::buffDestroySrv, node, std::placeholders::_1, std::placeholders::_2));
+    std::bind(&IIONode::buffDestroySrv, node, std::placeholders::_1, std::placeholders::_2),
+    rmw_qos_profile_services_default,
+    cb_group_buffer_destroy);
 
+  auto cb_group_buffer_refill = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   rclcpp::Service<adi_iio::srv::BufferRefill>::SharedPtr buffRefillSrv =
     node->create_service<adi_iio::srv::BufferRefill>(
     std::string(node->get_name()) + "/BufferRefill",
-    std::bind(&IIONode::buffRefillSrv, node, std::placeholders::_1, std::placeholders::_2));
+    std::bind(&IIONode::buffRefillSrv, node, std::placeholders::_1, std::placeholders::_2),
+    rmw_qos_profile_services_default,
+    cb_group_buffer_refill);
 
+  auto cb_group_buffer_enable_topic = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   rclcpp::Service<adi_iio::srv::BufferEnableTopic>::SharedPtr buffEnableTopicSrv =
     node->create_service<adi_iio::srv::BufferEnableTopic>(
     std::string(node->get_name()) + "/BufferEnableTopic",
-    std::bind(&IIONode::buffEnableTopicSrv, node, std::placeholders::_1, std::placeholders::_2));
+    std::bind(&IIONode::buffEnableTopicSrv, node, std::placeholders::_1, std::placeholders::_2),
+    rmw_qos_profile_services_default,
+    cb_group_buffer_enable_topic);
 
+  auto cb_group_buffer_disable_topic = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   rclcpp::Service<adi_iio::srv::BufferDisableTopic>::SharedPtr buffDisableTopicSrv =
     node->create_service<adi_iio::srv::BufferDisableTopic>(
     std::string(node->get_name()) + "/BufferDisableTopic",
-    std::bind(&IIONode::buffDisableTopicSrv, node, std::placeholders::_1, std::placeholders::_2));
+    std::bind(&IIONode::buffDisableTopicSrv, node, std::placeholders::_1, std::placeholders::_2),
+    rmw_qos_profile_services_default,
+    cb_group_buffer_disable_topic);
 
+  auto cb_group_list_devices = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   rclcpp::Service<adi_iio::srv::ListDevices>::SharedPtr listDevicesSrv =
     node->create_service<adi_iio::srv::ListDevices>(
     std::string(node->get_name()) + "/ListDevices",
-    std::bind(&IIONode::listDevicesSrv, node, std::placeholders::_1, std::placeholders::_2));
+    std::bind(&IIONode::listDevicesSrv, node, std::placeholders::_1, std::placeholders::_2),
+    rmw_qos_profile_services_default,
+    cb_group_list_devices);
 
+  auto cb_group_list_channels = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   rclcpp::Service<adi_iio::srv::ListChannels>::SharedPtr listChannelsSrv =
     node->create_service<adi_iio::srv::ListChannels>(
     std::string(node->get_name()) + "/ListChannels",
-    std::bind(&IIONode::listChannelsSrv, node, std::placeholders::_1, std::placeholders::_2));
+    std::bind(&IIONode::listChannelsSrv, node, std::placeholders::_1, std::placeholders::_2),
+    rmw_qos_profile_services_default,
+    cb_group_list_channels);
 
+  auto cb_group_list_attributes = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   rclcpp::Service<adi_iio::srv::ListAttributes>::SharedPtr listAttributesSrv =
     node->create_service<adi_iio::srv::ListAttributes>(
     std::string(node->get_name()) + "/ListAttributes",
-    std::bind(&IIONode::listAttributesSrv, node, std::placeholders::_1, std::placeholders::_2));
+    std::bind(&IIONode::listAttributesSrv, node, std::placeholders::_1, std::placeholders::_2),
+    rmw_qos_profile_services_default,
+    cb_group_list_attributes);
 
+  auto cb_group_scan_context = node->create_callback_group(
+    rclcpp::CallbackGroupType::MutuallyExclusive);
   rclcpp::Service<adi_iio::srv::ScanContext>::SharedPtr scanContextSrv =
     node->create_service<adi_iio::srv::ScanContext>(
     std::string(node->get_name()) + "/ScanContext",
-    std::bind(&IIONode::scanContextSrv, node, std::placeholders::_1, std::placeholders::_2));
+    std::bind(&IIONode::scanContextSrv, node, std::placeholders::_1, std::placeholders::_2),
+    rmw_qos_profile_services_default,
+    cb_group_scan_context);
 
   RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "IIO Node");
 
-  rclcpp::spin(node);
+  executor.add_node(node);
+  executor.spin();
+
   rclcpp::shutdown();
   return 0;
 }

--- a/src/iio_attr_topic.cpp
+++ b/src/iio_attr_topic.cpp
@@ -20,7 +20,7 @@
 
 IIOAttrTopic::IIOAttrTopic(
   std::shared_ptr<IIONode> nh, std::string topicName, std::string attrPath,
-  topicType_t type, int loopRate)
+  topicType_t type, double loopRate)
 : m_loopRate(loopRate)
 {
   RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "Created IIOAttrTopic");

--- a/src/iio_buffer.cpp
+++ b/src/iio_buffer.cpp
@@ -42,6 +42,7 @@ void IIOBuffer::destroyIIOBuffer()
     RCLCPP_DEBUG(rclcpp::get_logger("adi_iio_node"), "Destroyed buffer %p", (void *)m_buffer);
     iio_buffer_destroy(m_buffer);
     m_buffer = nullptr;
+    m_loopRate = nullptr;
   }
 }
 
@@ -231,10 +232,11 @@ bool IIOBuffer::push(std::string & message, std_msgs::msg::Int32MultiArray & dat
 }
 
 
-void IIOBuffer::enableTopic(std::string topic_name)
+void IIOBuffer::enableTopic(std::string topic_name, int loopRate)
 {
   m_topic_enabled = true;
   m_stopThread = false;
+  m_loopRate = std::make_shared<rclcpp::Rate>(loopRate);
 
   if (topic_name == "") {
     m_topic_name = IIOPath::toTopicName(m_device_path);
@@ -262,7 +264,9 @@ void IIOBuffer::publishingLoop()
       m_pub->publish(m_data);
     }
     // Sleep to maintain the loop rate
-    //std::this_thread::yield();
+    RCLCPP_DEBUG(
+      rclcpp::get_logger("adi_iio_node"), "Publishing loop %s", m_topic_name.c_str());
+    m_loopRate->sleep();
   }
 }
 

--- a/src/iio_buffer.cpp
+++ b/src/iio_buffer.cpp
@@ -232,7 +232,7 @@ bool IIOBuffer::push(std::string & message, std_msgs::msg::Int32MultiArray & dat
 }
 
 
-void IIOBuffer::enableTopic(std::string topic_name, int loopRate)
+void IIOBuffer::enableTopic(std::string topic_name, double loopRate)
 {
   m_topic_enabled = true;
   m_stopThread = false;

--- a/src/iio_node.cpp
+++ b/src/iio_node.cpp
@@ -27,7 +27,9 @@ IIONode::IIONode()
 {
   m_initialized = false;
   this->declare_parameter<std::string>("uri", "local:");
+  this->declare_parameter<int32_t>("timeout", 0);
   m_uri = this->get_parameter("uri").as_string();
+  m_timeout = this->get_parameter("timeout").as_int();
 
   m_ctx = iio_create_context_from_uri(m_uri.c_str());
 
@@ -42,6 +44,11 @@ IIONode::IIONode()
       rclcpp::get_logger("adi_iio_node"),
       "cannot create context from uri %s", m_uri.c_str());
   }
+
+  RCLCPP_INFO(
+    rclcpp::get_logger("adi_iio_node"),
+    "setting timeout to %d", m_timeout);
+  iio_context_set_timeout(m_ctx, m_timeout);
 }
 
 void IIONode::initBuffers()

--- a/src/iio_node.cpp
+++ b/src/iio_node.cpp
@@ -278,8 +278,8 @@ void IIONode::attrEnableTopicSrv(
 {
   RCLCPP_INFO(
     rclcpp::get_logger("adi_iio_node"),
-    "Service request /AttrEnableTopic %s with type %s with loop_rate %d Hz",
-    request->attr_path.c_str(), request->attr_path.c_str(), request->loop_rate);
+    "Service request /AttrEnableTopic %s with type %d with loop_rate %f Hz",
+    request->attr_path.c_str(), request->type, request->loop_rate);
 
   std::string message;
   response->success = rwAttrPath(request->attr_path, message);

--- a/src/iio_node.cpp
+++ b/src/iio_node.cpp
@@ -559,7 +559,7 @@ void IIONode::buffEnableTopicSrv(
   }
 
   if (m_bufferMap.find(path.getDeviceSegment()) != m_bufferMap.end()) {
-    m_bufferMap[path.getDeviceSegment()]->enableTopic(request->topic_name);
+    m_bufferMap[path.getDeviceSegment()]->enableTopic(request->topic_name, request->loop_rate);
     msg = "Success";
     setSuccessResponse(response, msg);
   } else {

--- a/srv/AttrEnableTopic.srv
+++ b/srv/AttrEnableTopic.srv
@@ -5,7 +5,7 @@ int8 BOOL = 3
 
 string attr_path
 string topic_name ""
-int32 loop_rate 1
+float64 loop_rate 1.0
 int8 type 0 # String: 0, Int: 1, Double: 2, Bool: 3
 ---
 bool success

--- a/srv/BufferEnableTopic.srv
+++ b/srv/BufferEnableTopic.srv
@@ -1,5 +1,6 @@
 string device_path
 string topic_name
+int32 loop_rate 1
 ---
 bool success
 string message

--- a/srv/BufferEnableTopic.srv
+++ b/srv/BufferEnableTopic.srv
@@ -1,6 +1,6 @@
 string device_path
 string topic_name
-int32 loop_rate 1
+float64 loop_rate 1.0
 ---
 bool success
 string message


### PR DESCRIPTION
- Loop Rate Control: regulates topic activity and prevents busy-waiting.
- Parallel Service Execution: Services are now processed by a `MultiThreadedExecutor`. Each service is assigned to its own `MutuallyExclusive CallbackGroup`. This allows different services to run concurrently, improving responsiveness. While services operate in parallel with each other, the `MutuallyExclusive CallbackGroup` ensures that concurrent calls to the same service are processed sequentially, 