### PR TITLE
Add System Tests with colcon integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,9 @@ install(DIRECTORY
 
 
 if(BUILD_TESTING)
+  # ============================================================================
+  # Linters tests
+  # ============================================================================
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights
   # comment the line when a copyright and license is added to all source files
@@ -86,6 +89,17 @@ if(BUILD_TESTING)
   # a copyright and license is added to all source files
   set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
+  # ============================================================================
+  # Integration tests
+  # ============================================================================
+  find_package(ament_cmake_ros REQUIRED)
+  find_package(launch_testing_ament_cmake)
+
+  function(add_ros_isolated_launch_test path)
+    set(RUNNER "${ament_cmake_ros_DIR}/run_test_isolated.py")
+    add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
+  endfunction()
+
 endif()
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,13 +81,9 @@ if(BUILD_TESTING)
   # Linters tests
   # ============================================================================
   find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # comment the line when a copyright and license is added to all source files
-  set(ament_cmake_copyright_FOUND TRUE)
-  # the following line skips cpplint (only works in a git repo)
-  # comment the line when this package is in a git repo and when
-  # a copyright and license is added to all source files
-  set(ament_cmake_cpplint_FOUND TRUE)
+  list(APPEND AMENT_LINT_AUTO_EXCLUDE
+    ament_cmake_flake8
+  )
   ament_lint_auto_find_test_dependencies()
   # ============================================================================
   # Integration tests
@@ -100,6 +96,27 @@ if(BUILD_TESTING)
     add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
   endfunction()
 
+  add_ros_isolated_launch_test(
+    test/smoke_test.test.py
+      ARGS "node_name:=adi_node" "uri:=ip:192.168.2.1" "timeout:=10"
+  )
+  add_ros_isolated_launch_test(
+    test/iio_path_utils.test.py
+      ARGS "node_name:=adi_node" "uri:=ip:192.168.2.1" "timeout:=5"
+  )
+  add_ros_isolated_launch_test(
+    test/buffer_srv.test.py
+      ARGS "node_name:=adi_node" "uri:=ip:192.168.2.1" "timeout:=5"
+  )
+  add_ros_isolated_launch_test(
+    test/attr_topic.test.py
+      ARGS "node_name:=adi_node" "uri:=ip:192.168.2.1" "timeout:=5"
+  )
+  add_ros_isolated_launch_test(
+    test/attr_srv.test.py
+      ARGS "node_name:=adi_node" "uri:=ip:192.168.2.1" "timeout:=5"
+  )
+  # ============================================================================
 endif()
 
 ament_package()

--- a/README.rst
+++ b/README.rst
@@ -38,6 +38,11 @@ detailed documentation into several sections:
 
 * For information on **parameters and services**, refer to the `Node Description`_ section.
 
+* **System Tests:** The package includes comprehensive system tests located in the
+  ``test/`` directory. These tests are integrated with ``colcon test`` and require
+  specific hardware (Analog Devices IIO devices) to execute. Refer to the test
+  directory's README for detailed setup instructions and execution guidelines.
+
 * For building this documentation, refer to `Building the Project Documentation Locally`_.
 
 

--- a/package.xml
+++ b/package.xml
@@ -26,8 +26,24 @@
   <depend>std_msgs</depend>
   <depend>libiio-dev</depend>
 
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_cppcheck</test_depend>
+  <test_depend>ament_cmake_cpplint</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+  <test_depend>ament_cmake_xmllint</test_depend>
+  <test_depend>ament_copyright</test_depend>
+  <!-- <test_depend>ament_flake8</test_depend> -->
+  <test_depend>ament_pep257</test_depend>
+
+  <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_ros</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_pytest</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>rclpy</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/src/attr_publisher.cpp
+++ b/src/attr_publisher.cpp
@@ -38,7 +38,7 @@ StringPubSub::~StringPubSub()
 
 void StringPubSub::publish(std::string msg)
 {
-  RCLCPP_INFO(
+  RCLCPP_DEBUG(
     rclcpp::get_logger("adi_iio_node"), "Publishing msg %s on topic %s",
     msg.c_str(), m_topic.c_str());
   auto message = std_msgs::msg::String();
@@ -71,7 +71,7 @@ Int32PubSub::~Int32PubSub()
 
 void Int32PubSub::publish(std::string msg)
 {
-  RCLCPP_INFO(
+  RCLCPP_DEBUG(
     rclcpp::get_logger("adi_iio_node"), "Publishing msg %s on topic %s",
     msg.c_str(), m_topic.c_str());
   auto message = std_msgs::msg::Int32();
@@ -108,7 +108,7 @@ BoolPubSub::~BoolPubSub()
 
 void BoolPubSub::publish(std::string msg)
 {
-  RCLCPP_INFO(
+  RCLCPP_DEBUG(
     rclcpp::get_logger("adi_iio_node"), "Publishing msg %s on topic %s",
     msg.c_str(), m_topic.c_str());
   auto message = std_msgs::msg::Bool();
@@ -146,7 +146,7 @@ Float32PubSub::~Float32PubSub()
 
 void Float32PubSub::publish(std::string msg)
 {
-  RCLCPP_INFO(
+  RCLCPP_DEBUG(
     rclcpp::get_logger("adi_iio_node"), "Publishing msg %s on topic %s",
     msg.c_str(), m_topic.c_str());
   auto message = std_msgs::msg::Float32();

--- a/src/iio_attr_topic.cpp
+++ b/src/iio_attr_topic.cpp
@@ -38,6 +38,12 @@ IIOAttrTopic::IIOAttrTopic(
     case TYPE_INT:
       m_pub = std::make_unique<Int32PubSub>(m_nh, this, m_topicName);
       break;
+    case TYPE_DOUBLE:
+      m_pub = std::make_unique<Float32PubSub>(m_nh, this, m_topicName);
+      break;
+    case TYPE_BOOL:
+      m_pub = std::make_unique<BoolPubSub>(m_nh, this, m_topicName);
+      break;
     default:
       m_pub = std::make_unique<StringPubSub>(m_nh, this, m_topicName);
       break;

--- a/src/iio_buffer.cpp
+++ b/src/iio_buffer.cpp
@@ -190,7 +190,7 @@ bool IIOBuffer::refill(std::string & message)
       }
 
       uint8_t * base_ptr = reinterpret_cast<uint8_t *>(iio_buffer_first(m_buffer, ch));
-      size_t step = iio_buffer_step(m_buffer); // Should be in bytes
+      size_t step = iio_buffer_step(m_buffer);  // Should be in bytes
       uint8_t * sample = base_ptr + (step * i);
 
       int32_t val = 0;
@@ -235,6 +235,11 @@ bool IIOBuffer::push(std::string & message, std_msgs::msg::Int32MultiArray & dat
       } else {
         ch = iio_device_find_channel(dev, channel.c_str(), true);
       }
+
+      uint8_t * base_ptr = reinterpret_cast<uint8_t *>(iio_buffer_first(m_buffer, ch));
+      size_t step = iio_buffer_step(m_buffer) * i;
+      uint8_t * sample = base_ptr + step;
+
       int32_t val = data.data[i * m_channels.size() + j];
       iio_channel_convert_inverse(ch, sample, &val);
     }

--- a/src/iio_buffer.cpp
+++ b/src/iio_buffer.cpp
@@ -144,7 +144,7 @@ bool IIOBuffer::createIIOBuffer(std::string & message, bool output, bool cyclic)
   m_data.layout.dim[1].stride = m_channels.size();
 
 
-  RCLCPP_DEBUG(
+  RCLCPP_INFO(
     rclcpp::get_logger("adi_iio_node"), "Created buffer %p, direction: %s, cyclic: %s",
     (void *)m_buffer, direction ? "output" : "input", cyclic ? "true" : "false");
   message = "Success";

--- a/src/iio_buffer.cpp
+++ b/src/iio_buffer.cpp
@@ -211,6 +211,8 @@ bool IIOBuffer::push(std::string & message, std_msgs::msg::Int32MultiArray & dat
 {
   std::lock_guard<std::mutex> lock(m_mutex);
   iio_device * dev = iio_context_find_device(m_nh->ctx(), m_device_path.c_str());
+  iio_channel * ch = nullptr;
+
   if (!m_buffer) {
     message = "Buffer not created";
     return false;
@@ -219,9 +221,20 @@ bool IIOBuffer::push(std::string & message, std_msgs::msg::Int32MultiArray & dat
   // get data from multiarray and add it to a memory "arena"
   for (int i = 0; i < m_samples_count; i++) {
     for (size_t j = 0; j < m_channels.size(); j++) {
-      iio_channel * ch = iio_device_find_channel(dev, m_channels[j].c_str(), true);
-      void * sample = reinterpret_cast<int32_t *>(iio_buffer_first(m_buffer, ch)) +
-        iio_buffer_step(m_buffer) * i;
+      auto channel = m_channels[j];
+
+      if (IIOPath::hasExtendedChannelFormat(channel)) {
+        auto [is_output, chn_name] = IIOPath::getExtendedChannelSegment(channel);
+        ch = iio_device_find_channel(dev, chn_name.c_str(), is_output);
+        if (!is_output) {
+          RCLCPP_ERROR(
+            rclcpp::get_logger("adi_iio_node"),
+            "Push only works for input channels");
+          return false;
+        }
+      } else {
+        ch = iio_device_find_channel(dev, channel.c_str(), true);
+      }
       int32_t val = data.data[i * m_channels.size() + j];
       iio_channel_convert_inverse(ch, sample, &val);
     }

--- a/src/iio_buffer.cpp
+++ b/src/iio_buffer.cpp
@@ -21,6 +21,7 @@ IIOBuffer::IIOBuffer(std::shared_ptr<IIONode> nh, std::string device_path)
   this->m_device_path = device_path;
   m_canceled = false;
   this->m_buffer = nullptr;
+  this->m_topic_enabled = false;
 }
 
 IIOBuffer::~IIOBuffer()

--- a/src/iio_buffer.cpp
+++ b/src/iio_buffer.cpp
@@ -223,7 +223,7 @@ bool IIOBuffer::push(std::string & message, std_msgs::msg::Int32MultiArray & dat
       void * sample = reinterpret_cast<int32_t *>(iio_buffer_first(m_buffer, ch)) +
         iio_buffer_step(m_buffer) * i;
       int32_t val = data.data[i * m_channels.size() + j];
-      iio_channel_convert(ch, sample, &val);
+      iio_channel_convert_inverse(ch, sample, &val);
     }
   }
 

--- a/src/iio_node.cpp
+++ b/src/iio_node.cpp
@@ -138,6 +138,10 @@ bool IIONode::rwAttrPath(std::string path, std::string & result, bool write, std
 
     if (write) {
       ret1 = iio_device_attr_write(dev, iio_path.getDeviceAttrSegment().c_str(), value.c_str());
+      if (ret1 <= 0) {
+        ret1 = iio_device_debug_attr_write(
+          dev, iio_path.getDeviceAttrSegment().c_str(), value.c_str());
+      }
       if (ret1 > 0) {
         RCLCPP_DEBUG(
           rclcpp::get_logger("adi_iio_node"),
@@ -158,6 +162,12 @@ bool IIONode::rwAttrPath(std::string path, std::string & result, bool write, std
 
     ret1 = iio_device_attr_read(
       dev, iio_path.getDeviceAttrSegment().c_str(), attr_val, MAX_ATTR_SIZE);
+    if (ret1 <= 0) {
+      ret1 = iio_device_debug_attr_read(
+        dev, iio_path.getDeviceAttrSegment().c_str(), attr_val, MAX_ATTR_SIZE
+      );
+    }
+
     if (ret1 > 0) {
       result = attr_val;
       ret = true;

--- a/src/iio_node.cpp
+++ b/src/iio_node.cpp
@@ -285,7 +285,7 @@ void IIONode::attrEnableTopicSrv(
   response->success = rwAttrPath(request->attr_path, message);
   response->message = message;
 
-  std::string local_topic_name = request->topic_name;
+  std::string local_topic_name = IIOPath::toTopicName(request->topic_name);
   if (local_topic_name == "") {
     local_topic_name = IIOPath::toTopicName(request->attr_path);
   }

--- a/src/iio_node.cpp
+++ b/src/iio_node.cpp
@@ -111,7 +111,7 @@ bool IIONode::rwAttrPath(std::string path, std::string & result, bool write, std
     if (val) {
       ret = true;
       result = val;
-      RCLCPP_INFO(
+      RCLCPP_DEBUG(
         rclcpp::get_logger("adi_iio_node"),
         "read context attribute \"%s\" with value \"%s\"",
         iio_path.getContextAttrSegment().c_str(), val);
@@ -139,7 +139,7 @@ bool IIONode::rwAttrPath(std::string path, std::string & result, bool write, std
     if (write) {
       ret1 = iio_device_attr_write(dev, iio_path.getDeviceAttrSegment().c_str(), value.c_str());
       if (ret1 > 0) {
-        RCLCPP_INFO(
+        RCLCPP_DEBUG(
           rclcpp::get_logger("adi_iio_node"),
           "wrote device attribute \"%s\" from device \"%s\" with value \"%s\"",
           iio_path.getDeviceAttrSegment().c_str(), iio_path.getDeviceSegment().c_str(),
@@ -161,7 +161,7 @@ bool IIONode::rwAttrPath(std::string path, std::string & result, bool write, std
     if (ret1 > 0) {
       result = attr_val;
       ret = true;
-      RCLCPP_INFO(
+      RCLCPP_DEBUG(
         rclcpp::get_logger("adi_iio_node"),
         "read device attribute \"%s\" from device \"%s\" with value \"%s\"",
         iio_path.getDeviceAttrSegment().c_str(), iio_path.getDeviceSegment().c_str(), attr_val);
@@ -203,7 +203,7 @@ bool IIONode::rwAttrPath(std::string path, std::string & result, bool write, std
     if (write) {
       ret1 = iio_channel_attr_write(ch, iio_path.getChannelAttrSegment().c_str(), value.c_str());
       if (ret1 > 0) {
-        RCLCPP_INFO(
+        RCLCPP_DEBUG(
           rclcpp::get_logger("adi_iio_node"),
           "wrote channel attribute \"%s\" from channel \"%s\" device \"%s\" with value \"%s\"",
           iio_path.getChannelAttrSegment().c_str(),
@@ -226,7 +226,7 @@ bool IIONode::rwAttrPath(std::string path, std::string & result, bool write, std
     if (ret1 > 0) {
       result = attr_val;
       ret = true;
-      RCLCPP_INFO(
+      RCLCPP_DEBUG(
         rclcpp::get_logger("adi_iio_node"),
         "read channel attribute \"%s\" from channel \"%s\" device \"%s\" with value \"%s\"",
         iio_path.getChannelAttrSegment().c_str(), iio_path.getChannelSegment().c_str(),

--- a/src/iio_node.cpp
+++ b/src/iio_node.cpp
@@ -224,9 +224,14 @@ bool IIONode::rwAttrPath(std::string path, std::string & result, bool write, std
         RCLCPP_WARN(
           rclcpp::get_logger(
             "adi_iio_node"),
-          "could not write attribute \"%s\" from channel \"%s\" device \"%s\" with value \"%s\"- errno %d - %s",
-          iio_path.getChannelAttrSegment().c_str(), iio_path.getChannelSegment().c_str(),
-          iio_path.getDeviceSegment().c_str(), value.c_str(), ret1, result.c_str());
+          "could not write attribute \"%s\" from channel \"%s\" device \"%s\" "
+          "with value \"%s\"- errno %d - %s",
+          iio_path.getChannelAttrSegment().c_str(),
+          iio_path.getChannelSegment().c_str(),
+          iio_path.getDeviceSegment().c_str(),
+          value.c_str(),
+          ret1,
+          result.c_str());
         return ret;
       }
     }
@@ -329,7 +334,7 @@ void IIONode::attrDisableTopicSrv(
   std::string message;
 
   std::string local_topic_name = request->topic_name;
-  local_topic_name = IIOPath::toTopicName(request->topic_name); // for compatibility with enable
+  local_topic_name = IIOPath::toTopicName(request->topic_name);  // for compatibility with enable
 
   if (m_attrTopicMap.find(local_topic_name) != m_attrTopicMap.end()) {
     m_attrTopicMap.erase(local_topic_name);
@@ -609,7 +614,7 @@ void IIONode::listDevicesSrv(
   const std::shared_ptr<adi_iio::srv::ListDevices::Request> request,
   std::shared_ptr<adi_iio::srv::ListDevices::Response> response)
 {
-  (void)request; // unused
+  (void)request;  // unused
   RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "Service request /ListDevices");
   std::string msg;
 
@@ -761,7 +766,7 @@ void IIONode::scanContextSrv(
   const std::shared_ptr<adi_iio::srv::ScanContext::Request> request,
   std::shared_ptr<adi_iio::srv::ScanContext::Response> response)
 {
-  (void)request; // unused
+  (void)request;  // unused
   RCLCPP_INFO(rclcpp::get_logger("adi_iio_node"), "Service request /ScanContext");
   std::string msg{"Found: "};
   std::vector<std::string> devices;

--- a/src/iio_path.cpp
+++ b/src/iio_path.cpp
@@ -128,6 +128,9 @@ std::string IIOPath::toExtendedChannelSegment(bool output, std::string chn_name)
 std::string IIOPath::toTopicName(std::string path)
 {
   std::replace(path.begin(), path.end(), '-', '_');
+  if (!path.empty() && path.front() != '/') {
+    path = '/' + path;
+  }
   return path;
 }
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,155 @@
+# Overview
+
+This directory contains system-level integration test definitions for the
+`iio_ros2` package. These tests validate the functionality of the ADI IIO ROS2
+node by launching the node and exercising its services and topics through
+realistic usage scenarios.
+
+## Integration with colcon
+
+The tests are designed to integrate seamlessly with ROS2's `colcon` build and
+test system. The package's `CMakeLists.txt` includes these launch tests within
+the colcon test framework, enabling automated validation during continuous
+integration and development workflows.
+
+## Prerequisites
+
+Before running these tests, ensure you have:
+
+1. **ROS2 Environment**: A properly configured ROS2 installation (tested with ROS2 Humble)
+2. **Workspace Setup**: This package built in a ROS2 workspace using `colcon build`
+3. **Hardware Requirements**:
+   - An Analog Devices Pluto (PlutoSDR) device
+   - USB connection to the host system
+   - Device accessible via IP (typically `192.168.2.1` for USB-connected Pluto)
+
+## Test Parameters
+
+The test files accept several parameters that must be provided when running:
+
+- `node_name`: Name for the test node instance (e.g., `"adi_node_test"`)
+- `uri`: IIO device URI (e.g., `"ip:192.168.2.1"` for Pluto over USB)
+- `timeout`: Service call timeout in seconds (e.g., `"5"`)
+
+These parameters are passed through the launch system to configure the test
+environment and target device.
+
+## Running Tests
+
+### Step-by-Step Test Execution
+
+1. **Build the Package**
+   ```bash
+   cd /path/to/your/ros2_workspace
+   colcon build --packages-select adi_iio
+   source install/setup.bash
+   ```
+
+2. **Hardware Setup**
+   - Connect your Pluto device via USB
+   - Verify device connectivity:
+     ```bash
+     # Check if device is accessible
+     iio_info -u ip:192.168.2.1
+     ```
+
+3. **Run All Tests with colcon**
+   ```bash
+   colcon test \
+        --event-handlers console_direct+ \
+        --base-paths ./src/iio_ros2 \
+            node_name:="adi_node_test" \
+            uri:="ip:192.168.2.1" \
+            timeout:="5"
+   ```
+
+   **Command Explanation:**
+   - `--event-handlers console_direct+`: Enables verbose console output for real-time test progress
+   - `--base-paths ./src/iio_ros2`: Limits test execution to this specific package
+   - The final arguments (e.g: `node_name`, `uri`, etc.) are test parameters passed to each test file
+
+4. **View Test Results**
+   ```bash
+   colcon test-result --verbose
+   ```
+
+### Running Individual Tests
+
+You can execute specific test files using `launch_test`:
+
+```bash
+# Example: Run attribute service tests
+launch_test src/iio_ros2/test/attr_srv.test.py \
+            node_name:="adi_node_test" \
+            uri:="ip:192.168.2.1" \
+            timeout:="5"
+
+# Example: Run buffer service tests
+launch_test src/iio_ros2/test/buffer_srv.test.py \
+            node_name:="adi_node_test" \
+            uri:="ip:192.168.2.1" \
+            timeout:="5"
+```
+
+Alternatively, you can run specific tests by filtering with the `--ctest-args -R <pattern>` option in colcon. For example, to run only the `attr_srv.test.py` test file:
+
+```bash
+colcon test --event-handlers console_direct+ \
+            --base-paths ./src/iio_ros2 \
+            --ctest-args -R attr_srv \
+            node_name:="adi_node_test" \
+            uri:="ip:192.168.2.1" \
+            timeout:="5"
+```
+
+Replace `attr_srv` with any substring matching the desired test file name (without the `.py` extension) to filter and run only those tests.
+
+```bash
+# Run only the smoke test
+colcon test --event-handlers console_direct+ \
+            --base-paths ./src/iio_ros2 \
+            --ctest-args -R smoke \
+            node_name:="adi_node_test" \
+            uri:="ip:192.168.2.1" \
+            timeout:="5"
+```
+
+### Debug Mode
+
+For verbose debugging output, you can modify any test file to enable debug logging by uncommenting the debug arguments in the node configuration:
+
+```python
+# In any .test.py file, find the adi_iio_node definition and uncomment:
+adi_iio_node = launch_ros.actions.Node(
+    # ...existing configuration...
+    arguments=[
+        "--ros-args",
+        "--log-level",
+        "debug",
+    ]
+)
+```
+
+This will provide detailed logging from the IIO node during test execution.
+
+## Test Files Description
+
+- **`smoke_test.test.py`**: Basic node startup and service availability validation
+- **`attr_srv.test.py`**: Attribute read/write service functionality tests
+- **`attr_topic.test.py`**: Attribute topic enable/disable functionality tests
+- **`buffer_srv.test.py`**: Buffer creation, data flow, and streaming tests
+- **`iio_path_utils.test.py`**: IIO path discovery and validation tests
+
+## Troubleshooting
+
+- **Device Not Found**: Verify Pluto is connected and accessible at the specified URI
+- **Permission Errors**: Ensure your user has access to USB devices (may require udev rules)
+- **Test Timeouts**: Increase the timeout parameter if tests fail due to slow hardware response
+- **Service Unavailable**: Check that the target device supports the required IIO capabilities
+
+## References
+
+
+- [ament_lint_auto](https://github.com/ament/ament_lint/blob/humble/ament_lint_auto/doc/index.rst)
+- [How to configure ament python linters in CMakeLists?](https://answers.ros.org/question/351012/how-to-configure-ament-python-linters-in-cmakelists/)
+- [Using black and flake8 in tandem](https://sbarnea.com/lint/black/)

--- a/test/attr_srv.test.py
+++ b/test/attr_srv.test.py
@@ -1,0 +1,312 @@
+# Copyright 2025 Analog Devices, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+import unittest
+
+import launch_ros
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import pytest
+import rclpy
+from adi_iio.srv import AttrReadString, AttrWriteString
+from rclpy.node import Node
+
+import launch
+
+SRV_TIMEOUT = 5.0  # [seconds]
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    """Launch the node under test."""
+    uri_arg = launch.actions.DeclareLaunchArgument(
+        "uri",
+        # default_value=['local:'],
+        description="The URI of the IIO device to connect to",
+    )
+    node_name_arg = launch.actions.DeclareLaunchArgument(
+        "node_name",
+        # default_value=['adi_iio_node'],
+        description="The name of the node to launch.",
+    )
+    timeout_arg = launch.actions.DeclareLaunchArgument(
+        "timeout",
+        default_value=["0"],
+        description="Timeout for service calls in seconds.",
+    )
+
+    uri = launch_ros.parameter_descriptions.ParameterValue(
+        launch.substitutions.LaunchConfiguration("uri"), value_type=str
+    )
+    node_name = launch_ros.parameter_descriptions.ParameterValue(
+        launch.substitutions.LaunchConfiguration("node_name"), value_type=str
+    )
+    timeout = launch_ros.parameter_descriptions.ParameterValue(
+        launch.substitutions.LaunchConfiguration("timeout"), value_type=int
+    )
+
+    adi_iio_node = launch_ros.actions.Node(
+        package="adi_iio",
+        executable="adi_iio_node",
+        name=launch.substitutions.LaunchConfiguration("node_name"),
+        parameters=[
+            {
+                "uri": uri,
+                "node_name": node_name,
+                "timeout": timeout,
+            }
+        ],
+    )
+
+    launch_description = launch.LaunchDescription()
+    launch_description.add_action(uri_arg)
+    launch_description.add_action(node_name_arg)
+    launch_description.add_action(timeout_arg)
+    launch_description.add_action(adi_iio_node)
+    launch_description.add_action(launch_testing.actions.ReadyToTest())
+
+    # Pass local parameters to each test
+    test_context = {
+        "node": adi_iio_node,
+    }
+
+    return launch_description, test_context
+
+
+class TestAttrServices(unittest.TestCase):
+    # Runs once when the test suite is started
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    # Runs before each test method
+    def setUp(self):
+        # Create a new ROS node to interact with the node under test
+        self.node = Node("test_adi_iio_node")
+        self.buffer = []
+
+    # Runs before each test method
+    def tearDown(self) -> None:
+        self.node.destroy_node()
+
+    def test_ctx_attr_read_string(self, proc_output, proc_info, test_args):
+        """The /AttrReadString service should be available and return a string for a valid IIOPath."""
+        attr_path = "uri"
+
+        client = self.create_attr_read_string_client(test_args["node_name"])
+        future = self.attr_read_string_request(client, attr_path)
+
+        response: AttrReadString.Response = future.result()
+        self.assertTrue(response.success,
+                        "Service call to /AttrReadString failed: ")
+        self.assertEqual(
+            response.message,
+            test_args["uri"],
+            "Expected readback value to match the URI used to launch the node.",
+        )
+
+    def test_dev_attr_read_string(self, proc_output, proc_info, test_args):
+        """The /AttrReadString service should be available and return a string for a valid IIOPath."""
+        # TODO: change with a valid path on the target runner
+        attr_path = "ad9361-phy/calib_mode"
+
+        client = self.create_attr_read_string_client(test_args["node_name"])
+        future = self.attr_read_string_request(client, attr_path)
+
+        response: AttrReadString.Response = future.result()
+        self.assertTrue(response.success,
+                        "Service call to /AttrReadString failed: ")
+        # Should check that the response.message contains a value
+        self.assertTrue(
+            response.message,
+            f"Expected readback value to be non-empty for attribute path: {attr_path}",
+        )
+
+    def test_chn_attr_read_string(self, proc_output, proc_info, test_args):
+        """The /AttrReadString service should be available and return a string for a valid IIOPath."""
+        attr_path = "ad9361-phy/voltage0/gain_control_mode"
+
+        client = self.create_attr_read_string_client(test_args["node_name"])
+        future = self.attr_read_string_request(client, attr_path)
+
+        response: AttrReadString.Response = future.result()
+        self.assertTrue(response.success,
+                        "Service call to /AttrReadString failed: ")
+        # Should check that the response.message contains a value
+        self.assertTrue(
+            response.message,
+            f"Expected readback value to be non-empty for attribute path: {attr_path}",
+        )
+
+    def test_invalid_attr_read_string_path(self, proc_output, proc_info, test_args):
+        """The /AttrReadString service should be available but fail or an invalid IIOPath."""
+        attr_path = "invalid"
+
+        client = self.create_attr_read_string_client(test_args["node_name"])
+        future = self.attr_read_string_request(client, attr_path)
+
+        response: AttrReadString.Response = future.result()
+        self.assertFalse(
+            response.success,
+            "Service call to /AttrReadString should have failed for invalid path"
+        )
+
+    def test_chn_attr_write_string(self, proc_output, proc_info, test_args):
+        """The /AttrWriteString service should be available and write a string for a valid IIOPath."""
+        attr_path = "ad9361-phy/altvoltage1/frequency"
+        value = str(int(3e9))
+
+        client = self.create_attr_write_string_client(test_args["node_name"])
+        future = self.attr_write_string_request(client, attr_path, value)
+
+        response: AttrWriteString.Response = future.result()
+        self.assertTrue(response.success,
+                        "Service call to /AttrWriteString failed: ")
+        print(f"Response message: {response.message}")
+
+        value = float(value)
+        readback_value = float(response.message)
+        self.assertAlmostEqual(
+            readback_value,
+            value,
+            delta=value * 0.01,  # Allow 1% tolerance
+            msg="Expected readback value to match the written value",
+        )
+
+    def test_attr_write_string_permission_denied(self, proc_output, proc_info, node, test_args):
+        """The /AttrWriteString service should be available but fail for read-only attributes."""
+        attr_path = "ad9361-phy/altvoltage1/frequency_available"
+        value = str(int(3e9))
+
+        client = self.create_attr_write_string_client(test_args["node_name"])
+        future = self.attr_write_string_request(client, attr_path, value)
+
+        response: AttrWriteString.Response = future.result()
+        self.assertEqual(
+            response.message,
+            "Permission denied",
+            "Expected write to read-only attribute to fail with 'Permission denied'",
+        )
+        self.assertFalse(
+            response.success,
+            "Service call to /AttrWriteString should have failed for read-only attribute",
+        )
+
+    def test_invalid_attr_write_string_path(self, proc_output, proc_info, test_args):
+        """The /AttrWriteString service should be available but fail for invalid IIOPath."""
+        attr_path = "invalid/iio/path"
+        value = str(random.randint(4000, 4500))  # Valid fan speed values
+
+        client = self.create_attr_write_string_client(test_args["node_name"])
+        future = self.attr_write_string_request(client, attr_path, value)
+
+        response = future.result()
+        self.assertFalse(
+            response.success,
+            "Service call to /AttrWriteString should have failed for invalid path"
+        )
+
+    def test_rw_attr_string_loopback(self, proc_output, proc_info, test_args):
+        """Test writing and reading back a string attribute."""
+        attr_path = "ad9361-phy/altvoltage1/frequency"
+        value = str(int(3e9))
+
+        client_write = self.create_attr_write_string_client(
+            test_args["node_name"])
+        future = self.attr_write_string_request(client_write, attr_path, value)
+
+        response: AttrWriteString.Response = future.result()
+        self.assertTrue(response.success,
+                        "Service call to /AttrWriteString failed: ")
+        print(f"Response message: {response.message}")
+
+        value = float(value)
+        readback_value = float(response.message)
+        self.assertAlmostEqual(
+            readback_value,
+            value,
+            delta=value * 0.01,  # Allow 1% tolerance
+            msg="Expected readback value to match the written value",
+        )
+
+        client_read = self.create_attr_read_string_client(
+            test_args["node_name"])
+        future = self.attr_read_string_request(client_read, attr_path)
+
+        response: AttrReadString.Response = future.result()
+        readback_value = float(response.message)
+        self.assertTrue(response.success,
+                        "Service call to /AttrReadString failed: ")
+        self.assertAlmostEqual(
+            readback_value,
+            value,
+            delta=value * 0.01,  # Allow 1% tolerance
+            msg="Expected readback value to match the written value",
+        )
+
+    # Utility methods used by the tests
+
+    def create_attr_read_string_client(self, node_name):
+        """Create a client for the AttrReadString service."""
+        client = self.node.create_client(
+            AttrReadString, f"{node_name}/AttrReadString")
+        self.assertTrue(
+            client.wait_for_service(timeout_sec=SRV_TIMEOUT),
+            f"Service /AttrReadString not available after {SRV_TIMEOUT} seconds.",
+        )
+        return client
+
+    def create_attr_write_string_client(self, node_name):
+        """Create a client for the AttrWriteString service."""
+        client = self.node.create_client(
+            AttrWriteString, f"{node_name}/AttrWriteString"
+        )
+        self.assertTrue(
+            client.wait_for_service(timeout_sec=SRV_TIMEOUT),
+            f"Service /AttrWriteString not available after {SRV_TIMEOUT} seconds.",
+        )
+        return client
+
+    def attr_read_string_request(self, client, attr_path):
+        """Create and send a request to the AttrReadString service."""
+        request = AttrReadString.Request()
+        request.attr_path = attr_path
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(
+            self.node, future, timeout_sec=SRV_TIMEOUT)
+        self.assertTrue(
+            future.done(),
+            f"Service call to /AttrReadString did not complete within {SRV_TIMEOUT} seconds.",
+        )
+        return future
+
+    def attr_write_string_request(self, client, attr_path, value):
+        """Create and send a request to the AttrWriteString service."""
+        request = AttrWriteString.Request()
+        request.attr_path = attr_path
+        request.value = value
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(
+            self.node, future, timeout_sec=SRV_TIMEOUT)
+        self.assertTrue(
+            future.done(),
+            f"Service call to /AttrWriteString did not complete within {SRV_TIMEOUT} seconds.",
+        )
+        return future

--- a/test/attr_topic.test.py
+++ b/test/attr_topic.test.py
@@ -1,0 +1,568 @@
+# Copyright 2025 Analog Devices, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import unittest
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List
+
+import adi_iio
+import adi_iio.srv
+import launch_ros
+import launch_ros.parameter_descriptions
+import launch_testing
+import launch_testing.actions
+import pytest
+import rclpy
+from adi_iio.srv import AttrDisableTopic, AttrEnableTopic
+from launch_testing_ros import WaitForTopics
+from rclpy.node import Node
+from std_msgs.msg import Bool, Float32, Int32, String
+
+import launch
+
+SRV_TIMEOUT = 5.0  # [seconds]
+
+
+class TopicType(Enum):
+    """Enum for topic data types."""
+
+    STRING = adi_iio.srv.AttrEnableTopic.Request.STRING
+    INT32 = adi_iio.srv.AttrEnableTopic.Request.INT
+    FLOAT32 = adi_iio.srv.AttrEnableTopic.Request.DOUBLE
+    BOOL = adi_iio.srv.AttrEnableTopic.Request.BOOL
+
+
+@dataclass
+class EnableTopicConfiguration:
+    """Configuration for enabling an attribute topic."""
+
+    attr_path: str
+    topic_name: str = ""
+    loop_rate: float = 10.0
+    topic_type: TopicType = TopicType.STRING
+
+    # Expected outcomes
+    expected_success: bool = True
+
+    # Validation parameters
+    validate_topic_creation: bool = True
+    validate_data_flow: bool = True
+    time_window: float = 5.0
+    rate_tolerance: float = 0.05  # 5% tolerance
+    buffer_length: int = 500
+
+    # Test behavior
+    description: str = ""
+    should_skip: bool = False
+    skip_reason: str = ""
+
+    def __post_init__(self):
+        """Set defaults based on configuration."""
+        if not self.description:
+            self.description = f"Enable {self.attr_path} as {self.topic_type.name} at {self.loop_rate}Hz"
+
+    @property
+    def expected_topics(self) -> List[str]:
+        """Generate expected topic names."""
+        prefix = self.topic_name if self.topic_name else self.attr_path.replace(
+            '-', '_')
+        if not prefix.startswith('/'):
+            prefix = f"/{prefix}"
+        return [f"{prefix}/read", f"{prefix}/write"]
+
+    @property
+    def expected_msg_type(self) -> str:
+        """Get expected message type string."""
+        type_mapping = {
+            TopicType.STRING: "std_msgs/msg/String",
+            TopicType.INT32: "std_msgs/msg/Int32",
+            TopicType.FLOAT32: "std_msgs/msg/Float32",
+            TopicType.BOOL: "std_msgs/msg/Bool"
+        }
+        return type_mapping[self.topic_type]
+
+
+@dataclass
+class DisableTopicConfiguration:
+    """Configuration for disabling an attribute topic."""
+
+    topic_name: str
+    topic_type: TopicType = TopicType.STRING
+
+    # Expected outcomes
+    expected_success: bool = True
+
+    # Validation parameters
+    validate_topic_removal: bool = True
+
+    # Test behavior
+    description: str = ""
+    should_skip: bool = False
+    skip_reason: str = ""
+
+    def __post_init__(self):
+        """Set defaults based on configuration."""
+        if not self.description:
+            self.description = f"Disable topic {self.topic_name} ({self.topic_type.name})"
+
+
+@dataclass
+class TestScenario:
+    """Complete test scenario that chains enable and disable operations."""
+
+    name: str
+    description: str
+    enable_configs: List[EnableTopicConfiguration]
+    disable_configs: List[DisableTopicConfiguration]
+
+    # Global test behavior
+    should_skip: bool = False
+    skip_reason: str = ""
+
+    def __post_init__(self):
+        """Validate configuration."""
+        if not self.enable_configs:
+            raise ValueError(
+                "Test scenario must have at least one enable configuration")
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    """Launch the node under test."""
+    uri_arg = launch.actions.DeclareLaunchArgument(
+        "uri",
+        # default_value=['local:'],
+        description="The URI of the IIO device to connect to",
+    )
+    node_name_arg = launch.actions.DeclareLaunchArgument(
+        "node_name",
+        # default_value=['adi_iio_node'],
+        description="The name of the node to launch.",
+    )
+    timeout_arg = launch.actions.DeclareLaunchArgument(
+        "timeout",
+        default_value=["0"],
+        description="Timeout for service calls in seconds.",
+    )
+
+    uri = launch_ros.parameter_descriptions.ParameterValue(
+        launch.substitutions.LaunchConfiguration("uri"), value_type=str
+    )
+    node_name = launch_ros.parameter_descriptions.ParameterValue(
+        launch.substitutions.LaunchConfiguration("node_name"), value_type=str
+    )
+    timeout = launch_ros.parameter_descriptions.ParameterValue(
+        launch.substitutions.LaunchConfiguration("timeout"), value_type=int
+    )
+
+    adi_iio_node = launch_ros.actions.Node(
+        package="adi_iio",
+        executable="adi_iio_node",
+        name=launch.substitutions.LaunchConfiguration("node_name"),
+        parameters=[
+            {
+                "uri": uri,
+                "node_name": node_name,
+                "timeout": timeout,
+            }
+        ],
+        # arguments=["--ros-args", "--log-level", "debug",]
+    )
+
+    launch_description = launch.LaunchDescription()
+    launch_description.add_action(uri_arg)
+    launch_description.add_action(node_name_arg)
+    launch_description.add_action(timeout_arg)
+    launch_description.add_action(adi_iio_node)
+    launch_description.add_action(launch_testing.actions.ReadyToTest())
+
+    # Pass local parameters to each test
+    test_context = {
+        "node": adi_iio_node,
+    }
+
+    return launch_description, test_context
+
+
+class TestAttrTopicServices(unittest.TestCase):
+    """Parameterized test class for attribute topic services."""
+
+    # Test scenarios with chained enable/disable operations
+    TEST_SCENARIOS = [
+        TestScenario(
+            name="basic_string_topic",
+            description="Basic string topic enable/disable cycle",
+            enable_configs=[
+                EnableTopicConfiguration(
+                    attr_path="xadc/voltage0/raw",
+                    topic_name="",
+                    loop_rate=10.0,
+                    topic_type=TopicType.STRING,
+                )
+            ],
+            disable_configs=[
+                # TODO: tbd - disable only uses the topic name as ID, type is not used!!
+                DisableTopicConfiguration(
+                    topic_name="xadc/voltage0/raw",
+                    topic_type=TopicType.STRING,
+                    expected_success=True,
+                    description="Disable raw input topic"
+                ),
+                DisableTopicConfiguration(
+                    topic_name="xadc/voltage0/raw",
+                    topic_type=TopicType.STRING,
+                    expected_success=False,
+                    description="Attempt to disable an already disabled raw input topic",
+                )
+            ]
+        ),
+
+        TestScenario(
+            name="multiple_topics_mixed_success",
+            description="Enable multiple topics, then disable with mixed success/failure",
+            enable_configs=[
+                EnableTopicConfiguration(
+                    attr_path="xadc/voltage0/raw",
+                    topic_name="raw0",
+                    loop_rate=5.0,
+                    topic_type=TopicType.STRING
+                ),
+                EnableTopicConfiguration(
+                    attr_path="xadc/voltage1/raw",
+                    topic_name="raw1",
+                    loop_rate=2.0,
+                    topic_type=TopicType.INT32
+                )
+            ],
+            disable_configs=[
+                DisableTopicConfiguration(
+                    topic_name="raw0",
+                    topic_type=TopicType.STRING,
+                    expected_success=True,
+                    description="Should successfully disable fan1 topic"
+                ),
+                DisableTopicConfiguration(
+                    topic_name="nonexistent_topic",
+                    topic_type=TopicType.STRING,
+                    expected_success=False,
+                    description="Should fail to disable non-existent topic"
+                ),
+                DisableTopicConfiguration(
+                    topic_name="raw1",
+                    topic_type=TopicType.INT32,
+                    expected_success=True,
+                    description="Should successfully disable GPU frequency topic"
+                )
+            ]
+        ),
+
+        TestScenario(
+            name="invalid_enable_followed_by_cleanup",
+            description="Try invalid enable, then cleanup operations",
+            enable_configs=[
+                EnableTopicConfiguration(
+                    attr_path="invalid/path/test",
+                    topic_name="invalid_topic",
+                    expected_success=False,
+                    validate_topic_creation=False,
+                    validate_data_flow=False,
+                    description="Should fail to enable invalid path"
+                )
+            ],
+            disable_configs=[
+                DisableTopicConfiguration(
+                    topic_name="invalid_topic",
+                    topic_type=TopicType.STRING,
+                    expected_success=False,
+                    validate_topic_removal=False,
+                    description="Should fail to disable topic that was never created"
+                )
+            ]
+        ),
+
+        TestScenario(
+            name="high_frequency_float_test",
+            description="High frequency float topic with proper cleanup",
+            enable_configs=[
+                EnableTopicConfiguration(
+                    attr_path="xadc/voltage0/raw",
+                    topic_name="raw0",
+                    loop_rate=80.0,
+                    topic_type=TopicType.FLOAT32,
+                    time_window=3.0,  # Shorter validation window for high freq
+                    description="High frequency accelerometer scale"
+                )
+            ],
+            disable_configs=[
+                DisableTopicConfiguration(
+                    topic_name="raw0",
+                    topic_type=TopicType.FLOAT32,
+                    description="Clean up high frequency topic"
+                )
+            ]
+        )
+    ]
+
+    # Runs once when the test suite is started
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = Node("test_adi_iio_node")
+        self.buffer = []
+
+    def tearDown(self) -> None:
+        self.node.destroy_node()
+
+    def execute_test_scenario(self, scenario: TestScenario, test_args: Dict[str, Any]):
+        """Execute a complete test scenario with chained enable(1)/disable(1+) operations."""
+        if scenario.should_skip:
+            self.skipTest(scenario.skip_reason)
+
+        self.node.get_logger().info(
+            f"Starting scenario: {scenario.name} - {scenario.description}")
+
+        # Execute all enable operations
+        for enable_config in scenario.enable_configs:
+            self.node.get_logger().info(
+                f"Executing enable: {enable_config.description}")
+            self.execute_enable_topic_test(enable_config, test_args)
+
+        # Execute all disable operations
+        for disable_config in scenario.disable_configs:
+            self.node.get_logger().info(
+                f"Executing disable: {disable_config.description}")
+            self.execute_disable_topic_test(disable_config, test_args)
+
+        self.node.get_logger().info(f"Completed scenario: {scenario.name}")
+
+    def execute_enable_topic_test(self, config: EnableTopicConfiguration, test_args: Dict[str, Any]):
+        """Execute an enable topic test with the given configuration."""
+        # Skip test if configured
+        if config.should_skip:
+            self.skipTest(config.skip_reason)
+
+        client = self.create_attr_enable_topic_client(test_args["node_name"])
+        future = self.attr_enable_topic_request(
+            client=client,
+            attr_path=config.attr_path,
+            topic_name=config.topic_name,
+            loop_rate=config.loop_rate,
+            type=config.topic_type.value
+        )
+
+        response: AttrEnableTopic.Response = future.result()
+
+        # Validate response success/failure
+        if config.expected_success:
+            self.assertTrue(
+                response.success,
+                f"Service call failed for {config.description}: {response.message}"
+            )
+
+            # Only do validation if the enable was expected to succeed
+            if config.validate_topic_creation:
+                self._validate_topic_creation(config)
+
+            if config.validate_data_flow:
+                self._validate_topic_data_and_rate(config)
+        else:
+            self.assertFalse(
+                response.success,
+                f"Service call should have failed for {config.description}"
+            )
+
+    def execute_disable_topic_test(self, config: DisableTopicConfiguration, test_args: Dict[str, Any]):
+        """Execute a disable topic test with the given configuration."""
+        if config.should_skip:
+            self.skipTest(config.skip_reason)
+
+        client = self.create_attr_disable_topic_client(test_args["node_name"])
+        future = self.attr_disable_topic_request(
+            client=client,
+            topic_name=config.topic_name,
+            type=config.topic_type.value
+        )
+
+        response: AttrDisableTopic.Response = future.result()
+
+        # Validate response success/failure
+        if config.expected_success:
+            self.assertTrue(
+                response.success,
+                f"Disable operation failed for {config.description}: {response.message}"
+            )
+        else:
+            self.assertFalse(
+                response.success,
+                f"Disable operation should have failed for {config.description}"
+            )
+
+        # Validate topic removal if requested
+        if config.validate_topic_removal and config.expected_success:
+            self._validate_topic_removed(config)
+
+    def _validate_topic_creation(self, config: EnableTopicConfiguration):
+        """Validate that expected topics are created with correct types."""
+        for expected_topic in config.expected_topics:
+            topic_found = False
+            type_correct = False
+
+            for topic_name, topic_types in self.node.get_topic_names_and_types():
+                if topic_name == expected_topic:
+                    topic_found = True
+                    if config.expected_msg_type in topic_types:
+                        type_correct = True
+                    break
+
+            self.assertTrue(
+                topic_found,
+                f"Expected topic {expected_topic} not found for {config.description}"
+            )
+            self.assertTrue(
+                type_correct,
+                f"Expected topic {expected_topic} has wrong type. Expected {config.expected_msg_type}"
+            )
+
+    def _validate_topic_removed(self, config: DisableTopicConfiguration):
+        """Validate that topic has been removed."""
+        time.sleep(0.5)  # small delay to allow Topic removal to propagate
+        topic_names = [name for name,
+                       _ in self.node.get_topic_names_and_types()]
+        for topic_name in topic_names:
+            self.assertFalse(
+                topic_name.startswith(config.topic_name),
+                f"Topic {topic_name} should have been removed after disabling {config.topic_name}"
+            )
+
+    def _validate_topic_data_and_rate(self, config: EnableTopicConfiguration):
+        """Validate topic data flow and publishing rate."""
+        # Get message type class
+        msg_type_mapping = {
+            TopicType.STRING: String,
+            TopicType.INT32: Int32,
+            TopicType.FLOAT32: Float32,
+            TopicType.BOOL: Bool
+        }
+        msg_class = msg_type_mapping[config.topic_type]
+
+        # Test only the read topic for rate validation
+        read_topic = config.expected_topics[0]  # Assuming first is read topic
+        expected_topic_list = [(read_topic, msg_class)]
+
+        time_start = time.time()
+        with WaitForTopics(
+            expected_topic_list,
+            timeout=SRV_TIMEOUT,
+            messages_received_buffer_length=config.buffer_length
+        ) as wait_for_topics:
+            time.sleep(config.time_window)
+            time_end = time.time()
+            elapsed_time = time_end - time_start
+
+            received_messages = wait_for_topics.received_messages(read_topic)
+
+            # Validate message count and rate
+            estimated_loop_rate = len(received_messages) / elapsed_time
+            expected_rate = config.loop_rate
+            tolerance = config.rate_tolerance * expected_rate
+
+            self.assertAlmostEqual(
+                estimated_loop_rate,
+                expected_rate,
+                delta=tolerance,
+                msg=f"Rate validation failed for {config.description}. "
+                    f"Expected: {expected_rate}Hz, Got: {estimated_loop_rate:.2f}Hz"
+            )
+
+    # Generate individual test methods for each scenario
+    def test_basic_string_topic_scenario(self, proc_output, proc_info, test_args):
+        """Test basic string topic enable/disable cycle."""
+        scenario = self.TEST_SCENARIOS[0]
+        self.execute_test_scenario(scenario, test_args)
+
+    def test_multiple_topics_mixed_success_scenario(self, proc_output, proc_info, test_args):
+        """Test multiple topics with mixed success/failure disable operations."""
+        scenario = self.TEST_SCENARIOS[1]
+        self.execute_test_scenario(scenario, test_args)
+
+    def test_invalid_enable_followed_by_cleanup_scenario(self, proc_output, proc_info, test_args):
+        """Test invalid enable followed by cleanup operations."""
+        scenario = self.TEST_SCENARIOS[2]
+        self.execute_test_scenario(scenario, test_args)
+
+    def test_high_frequency_float_scenario(self, proc_output, proc_info, test_args):
+        """Test high frequency float topic with proper cleanup."""
+        scenario = self.TEST_SCENARIOS[3]
+        self.execute_test_scenario(scenario, test_args)
+
+    # Helper methods
+    def create_attr_enable_topic_client(self, node_name):
+        """Create a client for the AttrEnableTopic service."""
+        client = self.node.create_client(
+            AttrEnableTopic, f"{node_name}/AttrEnableTopic"
+        )
+        self.assertTrue(
+            client.wait_for_service(timeout_sec=SRV_TIMEOUT),
+            f"Service /AttrEnableTopic not available after {SRV_TIMEOUT} seconds.",
+        )
+        return client
+
+    def create_attr_disable_topic_client(self, node_name):
+        """Create a client for the AttrDisableTopic service."""
+        client = self.node.create_client(
+            AttrDisableTopic, f"{node_name}/AttrDisableTopic"
+        )
+        self.assertTrue(
+            client.wait_for_service(timeout_sec=SRV_TIMEOUT),
+            f"Service /AttrDisableTopic not available after {SRV_TIMEOUT} seconds.",
+        )
+        return client
+
+    def attr_enable_topic_request(self, client, attr_path, topic_name="", loop_rate=10.0, type=adi_iio.srv.AttrEnableTopic.Request.STRING):
+        """Create and send a request to the AttrEnableTopic service."""
+        request = AttrEnableTopic.Request()
+        request.attr_path = attr_path
+        request.topic_name = topic_name
+        request.loop_rate = loop_rate
+        request.type = type
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(
+            self.node, future, timeout_sec=SRV_TIMEOUT)
+        self.assertTrue(
+            future.done(),
+            f"Service call to /AttrEnableTopic did not complete within {SRV_TIMEOUT} seconds.",
+        )
+        return future
+
+    def attr_disable_topic_request(self, client, topic_name, type):
+        """Create and send a request to the AttrDisableTopic service."""
+        request = AttrDisableTopic.Request()
+        request.topic_name = topic_name
+        request.type = type
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(
+            self.node, future, timeout_sec=SRV_TIMEOUT)
+        self.assertTrue(
+            future.done(),
+            f"Service call to /AttrDisableTopic did not complete within {SRV_TIMEOUT} seconds.",
+        )
+        return future

--- a/test/buffer_srv.test.py
+++ b/test/buffer_srv.test.py
@@ -1,0 +1,1048 @@
+# Copyright 2025 Analog Devices, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import unittest
+from typing import List
+
+import launch_ros
+import launch_ros.parameter_descriptions
+import launch_testing
+import launch_testing.actions
+import numpy as np
+import pytest
+import rclpy
+from adi_iio.srv import (AttrWriteString, BufferCreate, BufferDestroy,
+                         BufferDisableTopic, BufferEnableTopic, BufferRead,
+                         BufferRefill, BufferWrite)
+from launch_testing_ros import WaitForTopics
+from rclpy.node import Node
+from scipy import signal
+from std_msgs.msg import Int32MultiArray, MultiArrayDimension
+
+import launch
+
+SRV_TIMEOUT = 5.0  # [seconds]
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    """Launch the node under test."""
+    uri_arg = launch.actions.DeclareLaunchArgument(
+        "uri",
+        # default_value=['local:'],
+        description="The URI of the IIO device to connect to",
+    )
+    node_name_arg = launch.actions.DeclareLaunchArgument(
+        "node_name",
+        # default_value=['adi_iio_node'],
+        description="The name of the node to launch.",
+    )
+    timeout_arg = launch.actions.DeclareLaunchArgument(
+        "timeout",
+        default_value=["0"],
+        description="Timeout for service calls in seconds.",
+    )
+
+    uri = launch_ros.parameter_descriptions.ParameterValue(
+        launch.substitutions.LaunchConfiguration("uri"), value_type=str
+    )
+    node_name = launch_ros.parameter_descriptions.ParameterValue(
+        launch.substitutions.LaunchConfiguration("node_name"), value_type=str
+    )
+    timeout = launch_ros.parameter_descriptions.ParameterValue(
+        launch.substitutions.LaunchConfiguration("timeout"), value_type=int
+    )
+
+    adi_iio_node = launch_ros.actions.Node(
+        package="adi_iio",
+        executable="adi_iio_node",
+        name=launch.substitutions.LaunchConfiguration("node_name"),
+        parameters=[
+            {
+                "uri": uri,
+                "node_name": node_name,
+                "timeout": timeout,
+            }
+        ],
+        # arguments=[
+        #     "--ros-args",
+        #     "--log-level",
+        #     "debug",
+        # ]
+    )
+
+    launch_description = launch.LaunchDescription()
+    launch_description.add_action(uri_arg)
+    launch_description.add_action(node_name_arg)
+    launch_description.add_action(timeout_arg)
+    launch_description.add_action(adi_iio_node)
+    launch_description.add_action(launch_testing.actions.ReadyToTest())
+
+    # Pass local parameters to each test
+    test_context = {
+        "node": adi_iio_node,
+    }
+
+    return launch_description, test_context
+
+
+class TestBufferService(unittest.TestCase):
+    """Test the buffer service."""
+
+    # Runs once when the test suite is started
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = Node("test_adi_iio_node")
+        self.buffer = []
+
+    def tearDown(self) -> None:
+        self.node.destroy_node()
+
+    # ==========================================================================
+    # /BufferCreate
+    # ==========================================================================
+    def test_buffer_create_srv_valid_device(self, proc_output, proc_info, test_args, node):
+        """The /BufferCreate service should be available and functional."""
+        config = {
+            "device_path": "cf-ad9361-lpc",
+            "channels": ["voltage0", "voltage1"],
+            "samples_count": 32,
+        }
+        self.execute_scenario_buffer_create(
+            test_args,
+            config=config,
+            expected_success=True,
+        )
+
+        launch_testing.asserts.assertInStream(
+            proc_output,
+            str(config["samples_count"]),
+            node
+        )
+
+    def test_buffer_create_srv_invalid_device(self, proc_output, proc_info, test_args, node):
+        """The /BufferCreate service should handle invalid device paths gracefully."""
+        config = {
+            "device_path": "xadc",
+            "channels": ["voltage0", "voltage1"],
+            "samples_count": 32,
+        }
+        self.execute_scenario_buffer_create(
+            test_args,
+            config=config,
+            expected_success=False,
+        )
+
+    # ==========================================================================
+    # /BufferRefill
+    # ==========================================================================
+    def test_buffer_refill_srv_single_chn(self, proc_output, proc_info, test_args):
+        """The /BufferRefill service should be available and functional."""
+        config = {
+            "device_path": "cf-ad9361-lpc",
+            "channels": ["voltage0"],
+            "samples_count": 32,
+        }
+        self.execute_scenario_buffer_create(
+            test_args,
+            config=config,
+            expected_success=True,
+        )
+
+        for _ in range(10):
+            self.execute_scenario_buffer_refill(
+                test_args,
+                config=config,
+                expected_success=True,
+            )
+
+    def test_buffer_refill_srv_multiple_chn(self, proc_output, proc_info, test_args):
+        """The /BufferRefill service should be available and functional."""
+        config = {
+            "device_path": "cf-ad9361-lpc",
+            "channels": ["voltage0", "voltage1"],
+            "samples_count": 1024,
+        }
+        self.execute_scenario_buffer_create(
+            test_args,
+            config=config,
+            expected_success=True,
+        )
+
+        for _ in range(10):
+            self.execute_scenario_buffer_refill(
+                test_args,
+                config=config,
+                expected_success=True,
+            )
+
+    # ==========================================================================
+    # /BufferDestroy
+    # ==========================================================================
+    def test_buffer_destroy_srv_existing_buffer(self, proc_output, proc_info, test_args):
+        """The /BufferDestroy service should be available and functional."""
+        config = {
+            "device_path": "cf-ad9361-lpc",
+            "channels": ["voltage0", "voltage1"],
+            "samples_count": 32,
+        }
+        self.execute_scenario_buffer_create(
+            test_args,
+            config=config,
+            expected_success=True,
+        )
+
+        # Should succeed only when a buffer exists
+        self.execute_scenario_buffer_destroy(
+            test_args,
+            config=config,
+            expected_success=True,
+        )
+
+        for _ in range(10):
+            self.execute_scenario_buffer_destroy(
+                test_args,
+                config=config,
+                expected_success=False,
+            )
+
+    # ==========================================================================
+    # /BufferRead
+    # ==========================================================================
+    def test_buffer_read_valid_device(self, proc_output, proc_info, test_args):
+        """The /BufferRead service should be available and functional."""
+        config = {
+            "device_path": "cf-ad9361-lpc",
+            "channels": ["voltage0", "voltage1"],
+            "samples_count": 32,
+        }
+
+        self.execute_scenario_buffer_read(
+            test_args,
+            config=config,
+            expected_success=True,
+        )
+
+    def test_buffer_read_srv_invalid_device(self, proc_output, proc_info, test_args):
+        """The /BufferRead service should handle invalid device paths gracefully."""
+        config = {
+            "device_path": "xadc",
+            "channels": ["voltage0", "voltage1"],
+            "samples_count": 32,
+        }
+
+        self.execute_scenario_buffer_read(
+            test_args,
+            config=config,
+            expected_success=False,
+        )
+
+    def test_buffer_read_srv_single_chn(self, proc_output, proc_info, test_args):
+        """The /BufferRead service should be available and return the expected number of samples."""
+        config = {
+            "device_path": "cf-ad9361-lpc",
+            "channels": ["voltage0"],
+            "samples_count": 256,
+        }
+
+        for _ in range(10):
+            self.execute_scenario_buffer_read(
+                test_args,
+                config=config,
+                expected_success=True,
+            )
+
+    def test_buffer_read_srv_multiple_chn(self, proc_output, proc_info, test_args):
+        """The /BufferRead service should be available and return the expected number of samples."""
+        config = {
+            "device_path": "cf-ad9361-lpc",
+            "channels": ["voltage0", "voltage1"],
+            "samples_count": 1024,
+        }
+
+        for _ in range(10):
+            self.execute_scenario_buffer_read(
+                test_args,
+                config=config,
+                expected_success=True,
+            )
+
+    # ==========================================================================
+    # /BufferWrite
+    # ==========================================================================
+    def test_buffer_write_invalid_device(self, proc_output, proc_info, test_args):
+        """The /Buffer write should handle gracefully devices that are not buffer capable."""
+        config = {
+            "device_path": "ad9361-phy",  # NOT buffer capable
+            "channels": ["output_voltage0"],
+            "buffer": self.sine(
+                samples_count=1024,
+                amplitude=2 ** 14,
+                phase=0
+            ),
+            "cyclic": True
+        }
+
+        self.execute_scenario_buffer_write(
+            test_args,
+            config=config,
+            expected_success=False,
+        )
+        time.sleep(2)
+
+    def test_buffer_write_single_chn(self, proc_output, proc_info, test_args):
+        """The /BufferWrite service should be available and functional."""
+        config = {
+            "device_path": "cf-ad9361-dds-core-lpc",  # Buffer capable
+            "channels": ["output_voltage0"],
+            "buffer": self.sine(
+                samples_count=1024,
+                amplitude=2 ** 14,
+                phase=0
+            ),
+            "cyclic": True
+        }
+
+        self.execute_scenario_buffer_write(
+            test_args,
+            config=config,
+            expected_success=True,
+        )
+        time.sleep(2)
+
+    def test_buffer_write_multiple_chn(self, proc_output, proc_info, test_args):
+        """The /BufferWrite service should be available and functional."""
+        buffer, data_sine, data_cosine = self.sine_cosine_interleaved(
+            samples_count=1024,
+            amplitude=2 ** 14,
+            phase=0
+        )
+
+        config = {
+            "device_path": "cf-ad9361-dds-core-lpc",
+            "channels": ["voltage0", "output_voltage1"],
+            "buffer": buffer,
+            "cyclic": True
+        }
+
+        self.execute_scenario_buffer_write(
+            test_args,
+            config=config,
+            expected_success=True,
+        )
+        time.sleep(2)
+
+    # ==========================================================================
+    # /BufferRead + /BufferWrite: Loopback
+    # ==========================================================================
+    def test_buffer_read_write_loopback(self, proc_output, proc_info, test_args):
+        """Writes a cyclic buffer which is read back. Then compares the normalized buffers to validate they contain the same signal."""
+        client_attr_write = self.create_attr_write_string_client(
+            test_args["node_name"])
+        self.attr_write_string_request(
+            client_attr_write,
+            attr_path="ad9361-phy/loopback",
+            value="1"
+        )
+
+        # Write data
+        samples_count = 1024
+        buffer, write_sine, write_cosine = self.sine_cosine_interleaved(
+            samples_count=samples_count,
+            amplitude=2 ** 14,
+            phase=0
+        )
+        config = {
+            "device_path": "cf-ad9361-dds-core-lpc",
+            "channels": ["voltage0", "voltage1"],
+            "buffer": buffer,
+            "samples_count": samples_count,
+            "cyclic": True
+        }
+
+        response = self.execute_scenario_buffer_write(
+            test_args,
+            config=config,
+            expected_success=True,
+        )
+        time.sleep(1)
+
+        # Read Data
+        config = {
+            "device_path": "cf-ad9361-lpc",
+            "channels": ["voltage0", "voltage1"],
+            "samples_count": samples_count,
+        }
+        for _ in range(10):
+            response = self.execute_scenario_buffer_read(
+                test_args,
+                config=config,
+                expected_success=True,
+            )
+
+            read_buffer = np.array(response.buffer.data)
+            read_sine, read_cosine = self.deinterleave_data(read_buffer)
+
+            # Preprocess: normalize data
+            write_sine_norm = write_sine / np.max(np.abs(write_sine))
+            write_cosine_norm = write_cosine / np.max(np.abs(write_cosine))
+            read_sine_norm = read_sine / np.max(np.abs(read_sine))
+            read_cosine_norm = read_cosine / np.max(np.abs(read_cosine))
+
+            # Preprocess: align the read signals to the written ones
+            offset_sine, max_corr_sine = self.align_and_correlate(
+                write_sine_norm, read_sine_norm)
+
+            read_sine_norm = np.roll(read_sine_norm, offset_sine)
+            offset_cosine, max_corr_cosine = self.align_and_correlate(
+                write_cosine_norm, read_cosine_norm)
+            read_cosine_norm = np.roll(read_cosine_norm, offset_cosine)
+
+            # Validation: check if the read signals are similar to the written ones
+            self.assertGreaterEqual(
+                # Handle inverted signal after alignment
+                np.abs(max_corr_sine),
+                0.75,
+                f"Sine wave readback correlation too low: {max_corr_sine:.4f}"
+            )
+            self.assertGreaterEqual(
+                # Handle inverted signal after alignment
+                np.abs(max_corr_cosine),
+                0.75,
+                f"Cosine wave readback correlation too low: {max_corr_cosine:.4f}"
+            )
+
+    # ==========================================================================
+    # /BufferEnableTopic + /BufferDisableTopic
+    # ==========================================================================
+    def test_buffer_enable_topic(self, proc_output, proc_info, test_args):
+        # Setup debug mode
+        client_attr_write = self.create_attr_write_string_client(
+            test_args["node_name"])
+        self.attr_write_string_request(
+            client_attr_write,
+            attr_path="ad9361-phy/loopback",
+            value="1"
+        )
+
+        # Write data
+        samples_count = 1024
+        amplitude = 2**14
+        buffer, write_sine, write_cosine = self.sine_cosine_interleaved(
+            samples_count=samples_count,
+            amplitude=amplitude,
+            phase=0
+        )
+        config = {
+            "device_path": "cf-ad9361-dds-core-lpc",
+            "channels": ["voltage0", "voltage1"],
+            "buffer": buffer,
+            "samples_count": samples_count,
+            "cyclic": True
+        }
+
+        self.execute_scenario_buffer_write(
+            test_args,
+            config=config,
+            expected_success=True,
+        )
+
+        # Create buffer
+        config = {
+            "device_path": "cf-ad9361-lpc",
+            "channels": ["voltage0", "voltage1"],
+            "samples_count": 256,
+            "topic_name": "/cf_ad9361_lpc",
+            "loop_rate": 1.0,
+            # Topic validation config
+            "buffer_length": 500,  # number of messages to receive from the topic
+            "time_window": 10.0,  # how long to listen for data within the topic
+            "tolerance": 0.9  # difference tolerance for the loop rate validation
+        }
+        self.execute_scenario_buffer_create(
+            test_args,
+            config=config,
+            expected_success=True,
+        )
+
+        # Stream buffer to topic
+        self.execute_scenario_buffer_enable_topic(
+            test_args,
+            config=config,
+            expected_success=True
+        )
+        # Validate topic creation
+        topic_names = [val[0] for val in self.node.get_topic_names_and_types()]
+        self.assertIn(
+            config["topic_name"],
+            topic_names,
+            f"Topic {config['topic_name']} not found in the list of topics: {topic_names}",
+        )
+        # Validate topic loop_rate
+        expected_topic_list = [(config["topic_name"], Int32MultiArray)]
+        time_start = time.time()
+        with WaitForTopics(
+            expected_topic_list,
+            timeout=SRV_TIMEOUT,
+            messages_received_buffer_length=config["buffer_length"]
+        ) as wait_for_topics:
+            time.sleep(config["time_window"])
+            time_end = time.time()
+            elapsed_time = time_end - time_start
+
+            received_messages = wait_for_topics.received_messages(
+                config["topic_name"])
+
+            # Validate message count and rate
+            estimated_loop_rate = len(received_messages) / elapsed_time
+            expected_rate = config["loop_rate"]
+            tolerance = config["tolerance"] * expected_rate
+
+            self.assertAlmostEqual(
+                estimated_loop_rate,
+                expected_rate,
+                delta=tolerance,
+                msg=f"Loop Rate validation failed; Expected: {expected_rate}Hz, Got: {estimated_loop_rate:.2f}Hz"
+            )
+
+            for msg in received_messages:
+                data = msg.data
+                signal1, signal2 = self.deinterleave_data(data)
+                signal1 = np.array(signal1)
+                signal2 = np.array(signal2)
+
+                self.assertEqual(
+                    len(signal1),
+                    config["samples_count"],
+                    msg=f"Signal1: Expected {config['samples_count']} samples, got {len(signal1)}"
+                )
+                self.assertTrue(
+                    np.any(np.abs(signal1) > 500),
+                    msg="Signal1 should contain samples from the written buffer, not just noise."
+                )
+
+                self.assertEqual(
+                    len(signal2),
+                    config["samples_count"],
+                    msg=f"Signal2: Expected {config['samples_count']} samples, got {len(signal2)}"
+                )
+                self.assertTrue(
+                    np.any(np.abs(signal2) > 500),
+                    msg="Signal2 should contain samples from the written buffer, not just noise."
+                )
+
+        self.execute_scenario_buffer_disable_topic(
+            test_args,
+            config=config,
+            expected_success=True
+        )
+        time.sleep(4)
+        # Validate topic was disabled
+        topic_names = [val[0] for val in self.node.get_topic_names_and_types()]
+        self.assertNotIn(
+            config["topic_name"],
+            topic_names,
+            f"Topic {config['topic_name']} not found in the list of topics: {topic_names}",
+        )
+
+    # ==========================================================================
+    # Parameterized test scenarios
+    # ==========================================================================
+
+    def execute_scenario_buffer_create(self, test_args, config, expected_success):
+        client_create = self.create_buffer_create_client(
+            test_args["node_name"])
+        future = self.buffer_create_request(
+            client_create,
+            device_path=config["device_path"],
+            channels=config["channels"],
+            samples_count=config["samples_count"],
+        )
+
+        response: BufferCreate.Response = future.result()
+        if expected_success:
+            self.assertTrue(
+                response.success,
+                "BufferCreate service call failed: " + response.message,
+            )
+        else:
+            self.assertFalse(
+                response.success,
+                "BufferCreate service call should have failed but succeeded.",
+            )
+        return response
+
+    def execute_scenario_buffer_refill(self, test_args, config, expected_success):
+        client_refill = self.create_buffer_refill_client(
+            test_args["node_name"])
+        future = self.buffer_refill_request(
+            client_refill,
+            device_path=config["device_path"],
+        )
+        response: BufferRefill.Response = future.result()
+        if expected_success:
+            self.assertTrue(
+                response.success,
+                "BufferRefill service call failed: " + response.message,
+            )
+            self.assertEqual(
+                int(len(response.buffer.data)),
+                int(config["samples_count"]) * len(config["channels"]),
+                "BufferRefill did not return the expected number of samples.",
+            )
+        else:
+            self.assertFalse(
+                response.success,
+                "BufferRefill service call should have failed but succeeded.",
+            )
+        return response
+
+    def execute_scenario_buffer_destroy(self, test_args, config, expected_success):
+        client_destroy = self.create_buffer_destroy_client(
+            test_args["node_name"])
+        future = self.buffer_destroy_request(
+            client_destroy,
+            device_path=config["device_path"],
+        )
+
+        response: BufferDestroy.Response = future.result()
+
+        if expected_success:
+            self.assertTrue(
+                response.success,
+                "BufferDestroy service call failed: " + response.message,
+            )
+        else:
+            self.assertFalse(
+                response.success,
+                "BufferDestroy service call should have failed but succeeded.",
+            )
+        return response
+
+    def execute_scenario_buffer_read(self, test_args, config, expected_success):
+        client_read = self.create_buffer_read_client(test_args["node_name"])
+        future = self.buffer_read_request(
+            client_read,
+            device_path=config["device_path"],
+            channels=config["channels"],
+            samples_count=config["samples_count"],
+        )
+
+        response: BufferRead.Response = future.result()
+
+        if expected_success:
+            self.assertTrue(
+                response.success,
+                "BufferRead service call failed: " + response.message,
+            )
+            self.assertEqual(
+                int(len(response.buffer.data)),
+                int(config["samples_count"]) * len(config["channels"]),
+                "BufferRead did not return the expected number of samples.",
+            )
+        else:
+            self.assertFalse(
+                response.success,
+                "BufferRead service call should have failed but succeeded.",
+            )
+            self.assertEqual(
+                len(response.buffer.data),
+                0,
+                "BufferRead should return an empty buffer on failure.",
+            )
+        return response
+
+    def execute_scenario_buffer_write(self, test_args, config, expected_success):
+        client_write = self.create_buffer_write_client(test_args["node_name"])
+        future = self.buffer_write_request(
+            client_write,
+            device_path=config["device_path"],
+            channels=config["channels"],
+            buffer=config["buffer"],
+            cyclic=config["cyclic"],
+        )
+
+        response: BufferWrite.Response = future.result()
+
+        if expected_success:
+            self.assertTrue(
+                response.success,
+                "BufferWrite service call failed: " + response.message,
+            )
+        else:
+            self.assertFalse(
+                response.success,
+                "BufferWrite service call should have failed but succeeded.",
+            )
+        return response
+
+    def execute_scenario_buffer_enable_topic(self, test_args, config, expected_success):
+        client_buffer_enable_topic = self.create_buffer_enable_topic_client(
+            test_args["node_name"]
+        )
+        future = self.buffer_enable_topic_request(
+            client_buffer_enable_topic,
+            device_path=config["device_path"],
+            topic_name=config["topic_name"],
+            loop_rate=config["loop_rate"],
+        )
+
+        response: BufferEnableTopic.Response = future.result()
+
+        if expected_success:
+            self.assertTrue(
+                response.success,
+                "BufferEnableTopic service call failed: " + response.message,
+            )
+        else:
+            self.assertFalse(
+                response.success,
+                "BufferEnableTopic service call should have failed but succeeded.",
+            )
+        return response
+
+    def execute_scenario_buffer_disable_topic(self, test_args, config, expected_success):
+        client_buffer_disable_topic = self.create_buffer_disable_topic_client(
+            test_args["node_name"]
+        )
+        future = self.buffer_disable_topic_request(
+            client_buffer_disable_topic,
+            device_path=config["device_path"],
+        )
+        response: BufferDisableTopic.Response = future.result()
+
+        if expected_success:
+            self.assertTrue(
+                response.success,
+                "BufferDisableTopic service call failed: " + response.message,
+            )
+        else:
+            self.assertFalse(
+                response.success,
+                "BufferDisableTopic service call should have failed but succeeded.",
+            )
+        return response
+
+    # ==========================================================================
+    # Utility methods
+    # ==========================================================================
+
+    def create_buffer_create_client(self, node_name):
+        """Create a client for the BufferCreate service."""
+        client = self.node.create_client(
+            BufferCreate, f"{node_name}/BufferCreate")
+        self.assertTrue(
+            client.wait_for_service(timeout_sec=SRV_TIMEOUT),
+            f"Service /BufferCreate not available after {SRV_TIMEOUT} seconds.",
+        )
+        return client
+
+    def create_buffer_destroy_client(self, node_name):
+        """Create a client for the BufferDestroy service."""
+        client = self.node.create_client(
+            BufferDestroy, f"{node_name}/BufferDestroy")
+        self.assertTrue(
+            client.wait_for_service(timeout_sec=SRV_TIMEOUT),
+            f"Service /BufferDestroy not available after {SRV_TIMEOUT} seconds.",
+        )
+        return client
+
+    def create_buffer_enable_topic_client(self, node_name):
+        """Create a client for the BufferEnableTopic service."""
+        client = self.node.create_client(
+            BufferEnableTopic, f"{node_name}/BufferEnableTopic"
+        )
+        self.assertTrue(
+            client.wait_for_service(timeout_sec=SRV_TIMEOUT),
+            f"Service /BufferEnableTopic not available after {SRV_TIMEOUT} seconds.",
+        )
+        return client
+
+    def create_buffer_disable_topic_client(self, node_name):
+        """Create a client for the BufferDisableTopic service."""
+        client = self.node.create_client(
+            BufferDisableTopic, f"{node_name}/BufferDisableTopic"
+        )
+        self.assertTrue(
+            client.wait_for_service(timeout_sec=SRV_TIMEOUT),
+            f"Service /BufferDisableTopic not available after {SRV_TIMEOUT} seconds.",
+        )
+        return client
+
+    def create_buffer_read_client(self, node_name):
+        """Create a client for the BufferRead service."""
+        client = self.node.create_client(BufferRead, f"{node_name}/BufferRead")
+        self.assertTrue(
+            client.wait_for_service(timeout_sec=SRV_TIMEOUT),
+            f"Service /BufferRead not available after {SRV_TIMEOUT} seconds.",
+        )
+        return client
+
+    def create_buffer_refill_client(self, node_name):
+        """Create a client for the BufferRefill service."""
+        client = self.node.create_client(
+            BufferRefill, f"{node_name}/BufferRefill")
+        self.assertTrue(
+            client.wait_for_service(timeout_sec=SRV_TIMEOUT),
+            f"Service /BufferRefill not available after {SRV_TIMEOUT} seconds.",
+        )
+        return client
+
+    def create_buffer_write_client(self, node_name):
+        """Create a client for the BufferWrite service."""
+        client = self.node.create_client(
+            BufferWrite, f"{node_name}/BufferWrite")
+        self.assertTrue(
+            client.wait_for_service(timeout_sec=SRV_TIMEOUT),
+            f"Service /BufferWrite not available after {SRV_TIMEOUT} seconds.",
+        )
+        return client
+
+    def create_attr_write_string_client(self, node_name):
+        """Create a client for the /AttrWriteString service."""
+        client = self.node.create_client(
+            AttrWriteString, f"{node_name}/AttrWriteString")
+        self.assertTrue(
+            client.wait_for_service(timeout_sec=SRV_TIMEOUT),
+            f"Service /AttrWriteString not available after {SRV_TIMEOUT} seconds.",
+        )
+        return client
+
+    def buffer_create_request(
+        self, client, device_path: str, channels: List[str], samples_count: int
+    ):
+        """Create a request for the BufferCreate service."""
+        request = BufferCreate.Request()
+        request.device_path = device_path
+        request.channels = channels
+        request.samples_count = samples_count
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(
+            self.node, future, timeout_sec=SRV_TIMEOUT)
+        self.assertTrue(
+            future.done(),
+            "BufferCreate service call did not complete within the timeout.",
+        )
+        return future
+
+    def buffer_refill_request(self, client, device_path: str):
+        """Create a request for the BufferRefill service."""
+        request = BufferRefill.Request()
+        request.device_path = device_path
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(
+            self.node, future, timeout_sec=SRV_TIMEOUT)
+        self.assertTrue(
+            future.done(),
+            "BufferRefill service call did not complete within the timeout.",
+        )
+        return future
+
+    def buffer_destroy_request(self, client, device_path: str):
+        """Create a request for the BufferDestroy service."""
+        request = BufferDestroy.Request()
+        request.device_path = device_path
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(
+            self.node, future, timeout_sec=SRV_TIMEOUT)
+        self.assertTrue(
+            future.done(),
+            "BufferDestroy service call did not complete within the timeout.",
+        )
+        return future
+
+    def buffer_read_request(self, client, device_path: str, channels: List[str], samples_count: int):
+        """Create a request for the BufferRead service."""
+        request = BufferRead.Request()
+        request.device_path = device_path
+        request.channels = channels
+        request.samples_count = samples_count
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(
+            self.node, future, timeout_sec=SRV_TIMEOUT)
+        self.assertTrue(
+            future.done(),
+            "BufferRead service call did not complete within the timeout.",
+        )
+        return future
+
+    def buffer_write_request(
+        self,
+        client,
+        device_path: str,
+        channels: List[str],
+        buffer: Int32MultiArray,
+        cyclic: bool
+    ):
+        """Create a request for the BufferWrite service."""
+        request = BufferWrite.Request()
+        request.device_path = device_path
+        request.channels = channels
+        request.buffer = buffer
+        request.cyclic = cyclic
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(self.node, future, timeout_sec=SRV_TIMEOUT
+                                         )
+        self.assertTrue(
+            future.done(),
+            "BufferWrite service call did not complete within the timeout.",
+        )
+        return future
+
+    def buffer_enable_topic_request(
+        self,
+        client,
+        device_path: str,
+        topic_name: str,
+        loop_rate: float
+    ):
+        """Create a request for the BufferEnableTopic service."""
+        request = BufferEnableTopic.Request()
+        request.device_path = device_path
+        request.topic_name = topic_name
+        request.loop_rate = loop_rate
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(self.node, future, timeout_sec=SRV_TIMEOUT
+                                         )
+        self.assertTrue(
+            future.done(),
+            "BufferEnableTopic service call did not complete within the timeout.",
+        )
+        return future
+
+    def buffer_disable_topic_request(
+        self,
+        client,
+        device_path: str,
+    ):
+        """Create a request for the BufferDisableTopic service."""
+        request = BufferDisableTopic.Request()
+        request.device_path = device_path
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(self.node, future, timeout_sec=SRV_TIMEOUT
+                                         )
+        self.assertTrue(
+            future.done(),
+            "BufferDisableTopic service call did not complete within the timeout.",
+        )
+        return future
+
+    def attr_write_string_request(self, client, attr_path: str, value: str):
+        """Create a request for the AttrWriteString service."""
+        request = AttrWriteString.Request()
+        request.attr_path = attr_path
+        request.value = value
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(
+            self.node, future, timeout_sec=SRV_TIMEOUT)
+        self.assertTrue(
+            future.done(),
+            "AttrWriteString service call did not complete within the timeout.",
+        )
+        return future
+
+    def sine(self, samples_count: int, amplitude: int, phase: float = 0):
+        data = np.sin(np.linspace(0, 2 * np.pi + phase,
+                      samples_count)) * amplitude
+
+        data = data.astype(int)
+
+        buffer: Int32MultiArray = Int32MultiArray()
+        buffer.layout.dim.append(MultiArrayDimension(
+            label="samples",
+            size=len(data),
+            stride=len(data) * 1  # Assuming each sample is an Int32
+        ))
+        buffer.layout.dim.append(MultiArrayDimension(
+            label="channels",
+            size=1,
+            stride=1
+        ))
+        buffer.layout.data_offset = 0
+        buffer.data = data.tolist()
+
+        return buffer
+
+    def sine_cosine_interleaved(self, samples_count: int, amplitude: int, phase: float = 0):
+        t = np.linspace(0, 2 * np.pi, samples_count)
+        data_sine = np.sin(t + phase) * amplitude
+        data_sine = data_sine.astype(int)
+        data_cosine = np.sin(t + np.pi / 2 + phase) * amplitude
+        data_cosine = data_cosine.astype(int)
+
+        data_interleaved = self.interleave_data(data_sine, data_cosine)
+
+        buffer: Int32MultiArray = Int32MultiArray()
+        buffer.layout.dim.append(MultiArrayDimension(
+            label="samples",
+            size=samples_count,
+            stride=samples_count * 2  # 2 channels
+        ))
+        buffer.layout.dim.append(MultiArrayDimension(
+            label="channels",
+            size=2,
+            stride=2
+        ))
+        buffer.layout.data_offset = 0
+        buffer.data = data_interleaved.tolist()
+
+        return buffer, data_sine, data_cosine
+
+    def interleave_data(self, buffer1, buffer2):
+        if len(buffer1) != len(buffer2):
+            print("Error: Buffers must be of the same length")
+            return None
+
+        interleaved = []
+        for i in range(len(buffer1)):
+            interleaved.append(buffer1[i])
+            interleaved.append(buffer2[i])
+
+        return np.array(interleaved)
+
+    def deinterleave_data(self, data):
+        if len(data) % 2 != 0:
+            print("Error: Interleaved data must have an even length")
+            return None
+
+        buffer1 = data[::2]
+        buffer2 = data[1::2]
+
+        return buffer1, buffer2
+
+    def align_and_correlate(self, signal1, signal2):
+        """Aligns input signals using cross-correlation."""
+        correlation = signal.correlate(
+            signal1, signal2, mode='full', method='auto')
+        # Normalize to [-1;1]
+        correlation /= np.sqrt(np.sum(np.abs(signal2)**2)
+                               * np.sum(np.abs(signal1)**2))
+        lags = signal.correlation_lags(signal1.size, signal2.size, mode='full')
+
+        # Find the index of the peak correlation
+        # Use abs for magnitude of correlation
+        peak_idx = np.argmax(np.abs(correlation))
+        offset_samples = lags[peak_idx]
+        # This is the correlation value at optimal alignment
+        max_correlation_value = correlation[peak_idx]
+
+        return offset_samples, max_correlation_value

--- a/test/iio_path_utils.test.py
+++ b/test/iio_path_utils.test.py
@@ -1,0 +1,295 @@
+# Copyright 2025 Analog Devices, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+import itertools
+import unittest
+
+import launch_ros
+import launch_testing
+import launch_testing.actions
+import pytest
+import rclpy
+from adi_iio.srv import ListAttributes, ListChannels, ListDevices, ScanContext
+from rclpy.node import Node
+
+import launch
+
+SRV_TIMEOUT = 5.0  # [seconds]
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    """Launch the node under test."""
+    uri_arg = launch.actions.DeclareLaunchArgument(
+        "uri",
+        # default_value=['local:'],
+        description="The URI of the IIO device to connect to",
+    )
+    node_name_arg = launch.actions.DeclareLaunchArgument(
+        "node_name",
+        # default_value=['adi_iio_node'],
+        description="The name of the node to launch.",
+    )
+    timeout_arg = launch.actions.DeclareLaunchArgument(
+        "timeout",
+        default_value=["0"],
+        description="Timeout for service calls in seconds.",
+    )
+
+    uri = launch_ros.parameter_descriptions.ParameterValue(
+        launch.substitutions.LaunchConfiguration("uri"), value_type=str
+    )
+    node_name = launch_ros.parameter_descriptions.ParameterValue(
+        launch.substitutions.LaunchConfiguration("node_name"), value_type=str
+    )
+    timeout = launch_ros.parameter_descriptions.ParameterValue(
+        launch.substitutions.LaunchConfiguration("timeout"), value_type=int
+    )
+
+    adi_iio_node = launch_ros.actions.Node(
+        package="adi_iio",
+        executable="adi_iio_node",
+        name=launch.substitutions.LaunchConfiguration("node_name"),
+        parameters=[
+            {
+                "uri": uri,
+                "node_name": node_name,
+                "timeout": timeout,
+            }
+        ],
+    )
+
+    launch_description = launch.LaunchDescription()
+    launch_description.add_action(uri_arg)
+    launch_description.add_action(node_name_arg)
+    launch_description.add_action(timeout_arg)
+    launch_description.add_action(adi_iio_node)
+    launch_description.add_action(launch_testing.actions.ReadyToTest())
+
+    # Pass local parameters to each test
+    test_context = {
+        "node": adi_iio_node,
+    }
+
+    return launch_description, test_context
+
+
+class TestIIOPathUtils(unittest.TestCase):
+    """Validations for the IIO path utility services executed sequentially."""
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.device_paths = []
+        cls.channel_paths = []
+        cls.attr_paths = []
+        cls.scan_ctx_response = None
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    # Runs before each test method
+    def setUp(self):
+        # Create a new ROS node to interact with the node under test
+        self.node = Node("test_adi_iio_node")
+
+    # Runs before each test method
+    def tearDown(self) -> None:
+        self.node.destroy_node()
+
+    def test_00_list_devices(self, proc_output, proc_info, test_args):
+        """
+        /ListDevices service should be available and functional.
+
+        The response should contain a list of IIO device paths.
+        """
+        client = self.node.create_client(
+            ListDevices, f"/{test_args['node_name']}/ListDevices"
+        )
+        self.assertTrue(
+            client.wait_for_service(timeout_sec=SRV_TIMEOUT),
+            f"Service /ListDevices is not available within {SRV_TIMEOUT} seconds.",
+        )
+
+        request: ListDevices.Request = ListDevices.Request()
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(
+            self.node, future, timeout_sec=SRV_TIMEOUT)
+        self.assertTrue(
+            future.done(),
+            f"Service call to /ListDevices did not complete within {SRV_TIMEOUT} seconds.",
+        )
+
+        response: ListDevices.Response = future.result()
+        self.assertTrue(response.success,
+                        "Service call to /ListDevices failed.")
+        self.node.get_logger().info(
+            f"ListDevices response: {response.message}")
+
+        TestIIOPathUtils.device_paths = copy.deepcopy(response.data)
+
+    def test_01_list_channels(self, proc_output, proc_info, test_args):
+        """
+        /ListChannels service should be available and functional.
+
+        The channels should be listed for each device returned by /ListDevices.
+        """
+        client = self.node.create_client(
+            ListChannels, f"/{test_args['node_name']}/ListChannels"
+        )
+        self.assertTrue(
+            client.wait_for_service(timeout_sec=SRV_TIMEOUT),
+            f"Service /ListChannels is not available within {SRV_TIMEOUT} seconds.",
+        )
+
+        if not TestIIOPathUtils.device_paths:
+            self.node.get_logger().warn("No devices found. Skipping ListChannels test.")
+            return
+
+        channels = []
+        for device in TestIIOPathUtils.device_paths:
+            request = ListChannels.Request()
+            request.iio_path = device
+            future = client.call_async(request)
+            rclpy.spin_until_future_complete(
+                self.node, future, timeout_sec=SRV_TIMEOUT)
+            self.assertTrue(
+                future.done(),
+                f"Service call to /ListChannels for device {device} did not complete within {SRV_TIMEOUT} seconds.",
+            )
+
+            response: ListChannels.Response = future.result()
+            self.assertTrue(
+                response.success,
+                f"Service call to /ListChannels for device {device} failed.",
+            )
+            self.node.get_logger().info(
+                f"ListChannels response for {device}: {response.message}"
+            )
+
+            channels.extend(response.data)
+
+        TestIIOPathUtils.channel_paths = copy.deepcopy(channels)
+        self.node.get_logger().info(
+            f"Total channels found: {len(TestIIOPathUtils.channel_paths)}"
+        )
+
+    def test_02_list_attributes(self, proc_output, proc_info, test_args):
+        """
+        /ListAttributes service should be available and functional.
+
+        The attributes should be listed for each channel returned by /ListChannels.
+        """
+        client = self.node.create_client(
+            ListAttributes, f"/{test_args['node_name']}/ListAttributes"
+        )
+        self.assertTrue(
+            client.wait_for_service(timeout_sec=SRV_TIMEOUT),
+            f"Service /ListAttributes is not available within {SRV_TIMEOUT} seconds.",
+        )
+        if not TestIIOPathUtils.channel_paths:
+            self.node.get_logger().warn(
+                "No channels found. Skipping ListAttributes test."
+            )
+            return
+        attributes = []
+        for iio_path in itertools.chain(
+            TestIIOPathUtils.channel_paths,
+            TestIIOPathUtils.device_paths,
+            [""],  # IIOPath for context -> should return context attributes
+        ):
+            request = ListAttributes.Request()
+            request.iio_path = iio_path
+            future = client.call_async(request)
+            rclpy.spin_until_future_complete(
+                self.node, future, timeout_sec=SRV_TIMEOUT)
+            self.assertTrue(
+                future.done(),
+                f"Service call to /ListAttributes for IIOPath {iio_path} did not complete within {SRV_TIMEOUT} seconds.",
+            )
+
+            response: ListAttributes.Response = future.result()
+            self.assertTrue(
+                response.success,
+                f"Service call to /ListAttributes for channel {iio_path} failed.",
+            )
+            self.node.get_logger().info(
+                f"ListAttributes response for {iio_path}: {response.message}"
+            )
+
+            attributes.extend(response.data)
+        TestIIOPathUtils.attr_paths = copy.deepcopy(attributes)
+        self.node.get_logger().info(
+            f"Total attributes found: {len(TestIIOPathUtils.attr_paths)}"
+        )
+
+    def test_03_scan_context(self, proc_output, proc_info, test_args):
+        """
+        /ScanContext service should be available and functional.
+
+        The return should be IIOPath for: Devices, Channels, Attributes.
+        """
+        client = self.node.create_client(
+            ScanContext, f"/{test_args['node_name']}/ScanContext"
+        )
+        self.assertTrue(
+            client.wait_for_service(timeout_sec=SRV_TIMEOUT),
+            f"Service /ScanContext is not available within {SRV_TIMEOUT} seconds.",
+        )
+        request = ScanContext.Request()
+        future = client.call_async(request)
+        rclpy.spin_until_future_complete(
+            self.node, future, timeout_sec=SRV_TIMEOUT)
+        self.assertTrue(
+            future.done(),
+            f"Service call to /ScanContext did not complete within {SRV_TIMEOUT} seconds.",
+        )
+
+        response: ScanContext.Response = future.result()
+        self.assertTrue(response.success,
+                        "Service call to /ScanContext failed.")
+        self.node.get_logger().info(
+            f"ScanContext response: {response.message}")
+
+        TestIIOPathUtils.scan_ctx_response = copy.deepcopy(response)
+
+    def test_04_compare_results(self, proc_output, proc_info, test_args):
+        """
+        Compare the results of the previous methods to ensure consistency.
+
+        The /ScanContext service results should correlate with the results obtained
+        from /ListDevices, /ListChannels, and /ListAttributes services.
+        """
+        if not TestIIOPathUtils.scan_ctx_response:
+            self.fail("ScanContext response is empty. Cannot compare results.")
+
+        # Check devices
+        for device_path in TestIIOPathUtils.device_paths:
+            self.assertIn(
+                device_path, TestIIOPathUtils.scan_ctx_response.devices)
+
+        # Check channels
+        for channel_path in TestIIOPathUtils.channel_paths:
+            self.assertIn(
+                channel_path, TestIIOPathUtils.scan_ctx_response.channels)
+
+        # # Check attributes
+        for attr_path in itertools.chain(
+            TestIIOPathUtils.scan_ctx_response.context_attrs,
+            TestIIOPathUtils.scan_ctx_response.device_attrs,
+            TestIIOPathUtils.scan_ctx_response.channel_attrs,
+        ):
+            self.assertIn(attr_path, TestIIOPathUtils.attr_paths)

--- a/test/smoke_test.test.py
+++ b/test/smoke_test.test.py
@@ -1,0 +1,163 @@
+# Copyright 2025 Analog Devices, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import unittest
+
+import launch_ros
+import launch_testing
+import launch_testing.actions
+import pytest
+import rclpy
+from launch_testing.asserts import EXIT_OK
+from rclpy.node import Node
+
+import launch
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    """Launch the node under test."""
+    uri_arg = launch.actions.DeclareLaunchArgument(
+        "uri",
+        # default_value=['local:'],
+        description='The URI of the IIO device to connect to',
+    )
+    node_name_arg = launch.actions.DeclareLaunchArgument(
+        "node_name",
+        # default_value=['adi_iio_node'],
+        description="The name of the node to launch.",
+    )
+    timeout_arg = launch.actions.DeclareLaunchArgument(
+        "timeout",
+        default_value=["0"],
+        description="Timeout for service calls in seconds.",
+    )
+
+    uri = launch_ros.parameter_descriptions.ParameterValue(
+        launch.substitutions.LaunchConfiguration("uri"), value_type=str
+    )
+    node_name = launch_ros.parameter_descriptions.ParameterValue(
+        launch.substitutions.LaunchConfiguration("node_name"), value_type=str
+    )
+    timeout = launch_ros.parameter_descriptions.ParameterValue(
+        launch.substitutions.LaunchConfiguration("timeout"), value_type=int
+    )
+
+    adi_iio_node = launch_ros.actions.Node(
+        package="adi_iio",
+        executable="adi_iio_node",
+        name=launch.substitutions.LaunchConfiguration("node_name"),
+        parameters=[
+            {
+                "uri": uri,
+                "node_name": node_name,
+                "timeout": timeout,
+            }
+        ],
+    )
+
+    launch_description = launch.LaunchDescription()
+    launch_description.add_action(uri_arg)
+    launch_description.add_action(node_name_arg)
+    launch_description.add_action(timeout_arg)
+    launch_description.add_action(adi_iio_node)
+    launch_description.add_action(launch_testing.actions.ReadyToTest())
+
+    # Pass local parameters to each test
+    test_context = {
+        "node": adi_iio_node,
+    }
+
+    return launch_description, test_context
+
+
+class TestAdiIIONodeSmoke(unittest.TestCase):
+    # Runs once when the test suite is started
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    # Runs before each test method
+    def setUp(self):
+        # Create a new ROS node to interact with the node under test
+        self.node = Node("test_adi_iio_node")
+        self.buffer = []
+
+    # Runs before each test method
+    def tearDown(self) -> None:
+        self.node.destroy_node()
+
+    def test_node_starts(self, proc_output, proc_info, test_args):
+        """Test if the node starts correctly."""
+        self.node.get_logger().info(
+            f"Waiting for node {test_args['node_name']} to become available..."
+        )
+        found = False
+        start = time.time()
+        while time.time() - start < 20.0 and not found:
+            found = test_args["node_name"] in self.node.get_node_names()
+            time.sleep(0.1)
+
+        self.assertTrue(found), f"Node: {test_args['node_name']} not found!"
+        self.node.get_logger().info(
+            f"Node {test_args['node_name']} started successfully."
+        )
+
+    def test_services_available(self, proc_output, proc_info, test_args):
+        """Test if the required services are available."""
+        services = [
+            "/ScanContext",
+            "/AttrReadString",
+            "/AttrWriteString",
+            "/AttrEnableTopic",
+            "/AttrDisableTopic",
+            "/AttrDisableTopic",
+            "/BufferRead",
+            "/BufferWrite",
+            "/BufferCreate",
+            "/BufferDestroy",
+            "/BufferRefill",
+            "/BufferEnableTopic",
+            "/BufferDisableTopic",
+            "/ListDevices",
+            "/ListChannels",
+            "/ListAttributes",
+            "/ScanContext",
+        ]
+        # Prefix the services with the node name
+        services = [
+            f"/{test_args['node_name']}{service}" for service in services]
+
+        available_services = self.node.get_service_names_and_types()
+        available_service_names = [srv[0] for srv in available_services]
+
+        for service in services:
+            found = service in available_service_names
+            self.assertTrue(found), f"Service {service} not found!"
+
+            self.node.get_logger().info(f"Service {service} is available.")
+
+
+@launch_testing.post_shutdown_test()
+class AdiIIONodeShutdown(unittest.TestCase):
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(
+            proc_info, allowable_exit_codes=[EXIT_OK]
+        )


### PR DESCRIPTION
This PR adds a series of tests that can be executed after building the package by using the `colcon test` CLI utility:

## Motivation

The objective is to be able to build the package and validate the Node behavior using colcon with commands such as:

```bash
colcon build --packages-select adi_iio
# Execute system tests
colcon test
```

Validation is done with HW (Pluto) and service clients are used to reflect actual usage of the `adi_iio` Node.